### PR TITLE
Workaround: add chromium icons.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -285,16 +285,19 @@ void find_unmanaged_chromium_icons()
 {
     unsigned int n;
     Window *topwins, dummy;
-    XQueryTree(tray_data.dpy, DefaultRootWindow(tray_data.dpy), &dummy, &dummy, &topwins, &n);
+    XQueryTree(tray_data.dpy, DefaultRootWindow(tray_data.dpy), &dummy, &dummy,
+        &topwins, &n);
     if (topwins == NULL) return;
 
-    //Find toplevel windows (unmanaged) that have:
+    // Find toplevel windows (unmanaged) that have:
     //_NET_WM_WINDOW_TYPE(ATOM) == _NET_WM_WINDOW_TYPE_NOTIFICATION
-    //CHROMIUM_COMPOSITE_WINDOW(CARDINAL) == 1
-    Atom win_type        = XInternAtom(tray_data.dpy, "_NET_WM_WINDOW_TYPE", False);
-    Atom win_type_notif  = XInternAtom(tray_data.dpy, "_NET_WM_WINDOW_TYPE_NOTIFICATION", False);
-    Atom chrom_composite = XInternAtom(tray_data.dpy, "CHROMIUM_COMPOSITE_WINDOW", False);
-    for (unsigned int i=0; i<n; i++) {
+    // CHROMIUM_COMPOSITE_WINDOW(CARDINAL) == 1
+    Atom win_type = XInternAtom(tray_data.dpy, "_NET_WM_WINDOW_TYPE", False);
+    Atom win_type_notif =
+        XInternAtom(tray_data.dpy, "_NET_WM_WINDOW_TYPE_NOTIFICATION", False);
+    Atom chrom_composite =
+        XInternAtom(tray_data.dpy, "CHROMIUM_COMPOSITE_WINDOW", False);
+    for (unsigned int i = 0; i < n; i++) {
         Atom *aitem;
         unsigned int *citem;
         unsigned long nitems;
@@ -302,8 +305,10 @@ void find_unmanaged_chromium_icons()
         Bool ok = True;
         LOG_TRACE(("Chromium hack - checking window 0x%x\n", topwins[i]));
 
-        rc = x11_get_window_prop32(tray_data.dpy, topwins[i], win_type, XA_ATOM, (unsigned char **)&aitem, &nitems);
-        LOG_TRACE(("Chromium hack, ret: %x %x=%x %x\n", x11_ok(), rc, Success, nitems));
+        rc = x11_get_window_prop32(tray_data.dpy, topwins[i], win_type,
+            XA_ATOM, (unsigned char **)&aitem, &nitems);
+        LOG_TRACE(("Chromium hack, ret: %x %x=%x %x\n", x11_ok(), rc, Success,
+            nitems));
         if (!(x11_ok() && rc == SUCCESS && nitems == 1)) continue;
         LOG_TRACE(("Chromium hack, comp: %x=%x\n", aitem[0], win_type_notif));
         ok = aitem[0] == win_type_notif;
@@ -311,8 +316,10 @@ void find_unmanaged_chromium_icons()
         if (!ok) continue;
         LOG_TRACE(("Found toplevel notification window 0x%x\n", topwins[i]));
 
-        rc = x11_get_window_prop32(tray_data.dpy, topwins[i], chrom_composite, XA_CARDINAL, (unsigned char **)&citem, &nitems);
-        LOG_TRACE(("Chromium hack, ret: %x %x=%x %x\n", x11_ok(), rc, Success, nitems));
+        rc = x11_get_window_prop32(tray_data.dpy, topwins[i], chrom_composite,
+            XA_CARDINAL, (unsigned char **)&citem, &nitems);
+        LOG_TRACE(("Chromium hack, ret: %x %x=%x %x\n", x11_ok(), rc, Success,
+            nitems));
         if (!(x11_ok() && rc == SUCCESS && nitems == 1)) continue;
         LOG_TRACE(("Chromium hack, comp: %x=%x\n", aitem[0], win_type_notif));
         ok = citem[0] == 1;


### PR DESCRIPTION
Here is a crude hack, that works-for-me for issue #4, that finds chromium icons and slurps them as well. Probably not the correct way, I just used xprop on runaway brave-browser icon and guessed what are properties that identify these icons.