### PR TITLE
feat: add option to ignore window classes

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -85,6 +85,7 @@ void init_default_settings()
     settings.remote_click_cnt = REMOTE_CLICK_CNT_DEFAULT;
     settings.remote_click_pos.x = REMOTE_CLICK_POS_DEFAULT;
     settings.remote_click_pos.y = REMOTE_CLICK_POS_DEFAULT;
+    settings.ignored_classes = NULL;
 #ifdef DELAY_EMBEDDING_CONFIRMATION
     settings.confirmation_delay = 3;
 #endif
@@ -122,6 +123,21 @@ int parse_log_level(char *str, int **tgt, int silent)
         PARSING_ERROR("err, info, or trace expected", str);
         return FAILURE;
     }
+    return SUCCESS;
+}
+
+/* Parse list of ignored window classes */
+int parse_ignored_classes(char *str, struct WindowClass ***tgt, int silent)
+{
+    struct WindowClass *newclass = NULL;
+    const char *name = NULL;
+
+    for (name = strtok(str, ", "); name != NULL; name = strtok(NULL, ", ")) {
+        newclass = malloc(sizeof(struct WindowClass));
+        newclass->name = strdup(name);
+        LIST_ADD_ITEM(**tgt, newclass);
+    }
+
     return SUCCESS;
 }
 
@@ -521,6 +537,8 @@ struct Param params[] = {{"-display", NULL, "display", {&settings.display_str},
         (param_parser_t)&parse_wnd_type, 1, 1, 0, NULL},
     {NULL, "--xsync", "xsync", {&settings.xsync}, (param_parser_t)&parse_bool,
         1, 1, 1, "true"},
+    {NULL, "--ignore-classes", "ignore_classes", {&settings.ignored_classes},
+        (param_parser_t)&parse_ignored_classes, 1, 1, 0, NULL},
     {NULL, NULL, NULL, {NULL}}};
 
 void usage(char *progname)
@@ -568,6 +586,8 @@ void usage(char *progname)
         "SW, SE)\n"
         "    -i, --icon-size <n>         set basic icon size to <n>; default "
         "is 24\n"
+        "   --ignore-classes <classes>   ignore tray icons in xembed if the "
+        "tray window has one of the given classes, separated by commas\n"
         "    -h, --help                  show this message\n"
 #ifdef DEBUG
         "    --log-level <level>         set the level of output to either "

--- a/src/settings.h
+++ b/src/settings.h
@@ -18,6 +18,12 @@
 /* Default name of configuration file */
 #define STALONETRAY_RC "stalonetrayrc"
 
+struct WindowClass {
+    char *name;
+    struct WindowClass *next;
+    struct WindowClass *prev;
+};
+
 struct Settings {
     /* Flags */
     int parent_bg; /* Enable pseudo-transparency using parents' background*/
@@ -35,6 +41,9 @@ struct Settings {
     int kludge_flags; /* What kludges to activate */
 
     int need_help; /* Print usage and exit */
+
+    /* Lists of strings */
+    struct WindowClass *ignored_classes; /* List of window classes to ignore */
 
     /* Strings */
     char *display_str; /* Name of the display */

--- a/src/xutils.c
+++ b/src/xutils.c
@@ -15,6 +15,7 @@
 
 #include <limits.h>
 #include <unistd.h>
+#include <string.h>
 
 #include "xutils.h"
 
@@ -379,6 +380,18 @@ int x11_parse_color(Display *dpy, char *str, XColor *color)
         dpy, XDefaultColormap(dpy, DefaultScreen(dpy)), str, color);
     if (rc) XAllocColor(dpy, XDefaultColormap(dpy, DefaultScreen(dpy)), color);
     return x11_ok() && rc;
+}
+
+char *x11_get_window_class(Display *dpy, Window w) {
+    XClassHint hint;
+    char *classname = NULL;
+
+    XGetClassHint(dpy, w, &hint);
+    classname = strdup(hint.res_class);
+    XFree(hint.res_name);
+    XFree(hint.res_class);
+
+    return classname;
 }
 
 #ifdef DEBUG

--- a/src/xutils.h
+++ b/src/xutils.h
@@ -67,6 +67,9 @@ int x11_get_window_abs_coords(Display *dpy, Window dst, int *x, int *y);
 /* Get window name. NOT THREAD SAFE. Returns pointer to static buffer */
 char *x11_get_window_name(Display *dpy, Window dst, char *def);
 
+/* Get window class name. Returns pointer to string created with strdup() */
+char *x11_get_window_class(Display *dpy, Window w);
+
 /* Find subwindow by name */
 Window x11_find_subwindow_by_name(Display *dpy, Window tgt, char *name);
 

--- a/stalonetray.xml.in
+++ b/stalonetray.xml.in
@@ -200,6 +200,14 @@
   </varlistentry>
 
   <varlistentry>
+  <term><option>--ignore-classes</option> <replaceable>classes</replaceable></term>
+  <term><option>ignore_classes</option> <replaceable>classes</replaceable></term>
+  <listitem><para>Set X11 window class names to be ignored by stalonetray.
+  Class names are separated by commas: <userinput>class1,class2,...</userinput>.
+  </para></listitem>
+  </varlistentry>
+
+  <varlistentry>
   <term><option>--log-level</option> <replaceable>level</replaceable></term>
   <term><option>log_level</option> <replaceable>level</replaceable></term>
   <listitem><para>Set the amount of info to be output by stalonetray to the


### PR DESCRIPTION
This PR adds an option for the user to specify through the configuration file a list of X11 window class names that stalonetray should ignore.

Use case: some people would prefer an application that always displays a tray icon without an option to disable it (e.g. fcitx) to be ignored by stalonetray.
