### PR TITLE
feat: support multiple arguments in ignore-classes

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -1093,7 +1093,7 @@ struct Param params[] = {
     },
     {
         .short_name = NULL,
-        .long_name = "--ignore-classes",
+        .long_name = NULL,
         .rc_name = "ignore_classes",
         .references = { (void *) &settings.ignored_classes },
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -134,11 +134,11 @@ int parse_ignored_classes(int argc, const char **argv, void **references, int si
 {
     struct WindowClass **classes = (struct WindowClass **) references[0];
     struct WindowClass *newclass = NULL;
-    const char *name = NULL;
+    int i;
 
-    for (name = strtok((char *) argv[0], ", "); name != NULL; name = strtok(NULL, ", ")) {
+    for (i = 0; i < argc; i++) {
         newclass = malloc(sizeof(struct WindowClass));
-        newclass->name = strdup(name);
+        newclass->name = strdup(argv[i]);
         LIST_ADD_ITEM(*classes, newclass);
     }
 
@@ -1100,7 +1100,7 @@ struct Param params[] = {
         .pass = 1,
 
         .min_argc = 1,
-        .max_argc = 1,
+        .max_argc = 0,
 
         .default_argc = 0,
         .default_argv = NULL,

--- a/src/settings.c
+++ b/src/settings.c
@@ -1543,7 +1543,7 @@ void parse_rc()
 
         for (p = params; p->parser != NULL; p++) {
             if (p->rc_name != NULL && strcmp(argv[0], p->rc_name) == 0) {
-                if (argc - 1 < p->min_argc || argc - 1 > p->max_argc) {
+                if (argc - 1 < p->min_argc || (p->max_argc && argc - 1 > p->max_argc)) {
                     DIE(("Configuration file parse error at %s:%d: "
                          "invalid number of args for \"%s\" (%d-%d required)\n",
                         settings.config_fname, lnum,

--- a/stalonetray.xml.in
+++ b/stalonetray.xml.in
@@ -200,7 +200,6 @@
   </varlistentry>
 
   <varlistentry>
-  <term><option>--ignore-classes</option> <replaceable>classes</replaceable></term>
   <term><option>ignore_classes</option> <replaceable>classes</replaceable></term>
   <listitem><para>Set X11 window class names to be ignored by stalonetray.
   Class names are separate arguments: <userinput>class1 class2 ...</userinput>.

--- a/stalonetray.xml.in
+++ b/stalonetray.xml.in
@@ -203,7 +203,7 @@
   <term><option>--ignore-classes</option> <replaceable>classes</replaceable></term>
   <term><option>ignore_classes</option> <replaceable>classes</replaceable></term>
   <listitem><para>Set X11 window class names to be ignored by stalonetray.
-  Class names are separated by commas: <userinput>class1,class2,...</userinput>.
+  Class names are separate arguments: <userinput>class1 class2 ...</userinput>.
   </para></listitem>
   </varlistentry>
 


### PR DESCRIPTION
Makes it so `ignore_classes` takes multiple arguments, assuming each one is a class name to ignore, instead of accepting a single argument of comma-separated class names.

This way we can go from this:

```
ignore_classes class1,class2,class3
```

to this:

```
ignore_classes class1 class2 class3
```

Additionally a fix was added, as parameters having a nil `max_argc` was not enough to allow for unlimited arguments due to the way the argument count was validated in `parse_rc()`.
