### PR TITLE
cli: 'grow_gravity' => 'grow-gravity'

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -645,7 +645,7 @@ struct Param params[] = {
     },
     {
         .short_name = NULL,
-        .long_name = "--grow_gravity",
+        .long_name = "--grow-gravity",
         .rc_name = "grow_gravity",
         .references = { (void *) &settings.grow_gravity },
 


### PR DESCRIPTION
CLI arguments use dash as word separator.
'grow-gravity' style was accidentally changed in https://github.com/kolbusa/stalonetray/pull/27.