### PR TITLE
fix: Handle XGetClassHint() failures

### DIFF
--- a/src/xutils.c
+++ b/src/xutils.c
@@ -384,9 +384,15 @@ int x11_parse_color(Display *dpy, char *str, XColor *color)
 
 char *x11_get_window_class(Display *dpy, Window w) {
     XClassHint hint;
+    Status res = 0;
     char *classname = NULL;
 
-    XGetClassHint(dpy, w, &hint);
+    res = XGetClassHint(dpy, w, &hint);
+    if (res == 0) {
+        LOG_TRACE(("XGetClassHint(dpy, 0x%x, &hint) failed: %x", w, res));
+        return NULL;
+    }
+
     classname = strdup(hint.res_class);
     XFree(hint.res_name);
     XFree(hint.res_class);


### PR DESCRIPTION
`XGetClassHint()` will not initialize passed in `hint` structure, if the call fails.  Accessing `hint.res_name` and `hint.res_class` accesses random memory if `XGetClassHint()` failed.

Also, refactored `add_icon` error handing a bit.  Hopefully, it is easier to read in this form.  As there are a few cases when `classname` would be unnecessary, I've moved `classname` initialization to be after those are checked.