### PR TITLE
feat: allow scrolling outside the scrollbars

### DIFF
--- a/src/scrollbars.c
+++ b/src/scrollbars.c
@@ -70,6 +70,14 @@ void scrollbars_create()
         tray_data.scrollbars_data.scrollbar[SB_WND_RHT] = None;
     }
     scrollbars_update();
+    
+    if (settings.scroll_everywhere && settings.scrollbars_mode != SB_MODE_NONE) {
+        XGrabButton(tray_data.dpy, Button5, AnyModifier, tray_data.tray, False,
+                ButtonReleaseMask, GrabModeAsync, GrabModeAsync, None, None);
+        XGrabButton(tray_data.dpy, Button4, AnyModifier, tray_data.tray, False,
+                ButtonReleaseMask, GrabModeAsync, GrabModeAsync, None, None);
+    }
+
     for (i = 0; i < SB_WND_MAX; i++)
         if (tray_data.scrollbars_data.scrollbar[i] != None) {
 #ifndef DEBUG_SCROLLBAR_POSITIONS

--- a/src/settings.c
+++ b/src/settings.c
@@ -86,6 +86,7 @@ void init_default_settings()
     settings.remote_click_pos.x = REMOTE_CLICK_POS_DEFAULT;
     settings.remote_click_pos.y = REMOTE_CLICK_POS_DEFAULT;
     settings.ignored_classes = NULL;
+    settings.scroll_everywhere = 0;
 #ifdef DELAY_EMBEDDING_CONFIRMATION
     settings.confirmation_delay = 3;
 #endif
@@ -901,6 +902,22 @@ struct Param params[] = {
     },
     {
         .short_name = NULL,
+        .long_name = "--scroll-everywhere",
+        .rc_name = "scroll_everywhere",
+        .references = { (void *) &settings.scroll_everywhere },
+
+        .pass = 1,
+
+        .min_argc = 0,
+        .max_argc = 1,
+
+        .default_argc = 1,
+        .default_argv = {"true"},
+
+        .parser = (param_parser_t) &parse_bool
+    },
+    {
+        .short_name = NULL,
         .long_name = "--skip-taskbar",
         .rc_name = "skip_taskbar",
         .references = { (void *) &settings.skip_taskbar },
@@ -1249,6 +1266,7 @@ void usage(char *progname)
         "                                or disable\n"
         "    --scrollbars-step <n>       set scrollbar step to n pixels\n"
         "    --scrollbars-size <n>       set scrollbar size to n pixels\n"
+        "    --scroll-everywhere         enable scrolling outside of the scrollbars too\n"
         "    --slot-size <w>[x<h>]       set icon slot size in pixels\n"
         "                                if omitted, hight is set equal to width\n"
         "    --skip-taskbar              hide tray`s window from the taskbar\n"

--- a/src/settings.h
+++ b/src/settings.h
@@ -39,6 +39,7 @@ struct Settings {
     int shrink_back_mode; /* Keep tray's window size minimal */
     int dockapp_mode; /* Activate dockapp mode */
     int kludge_flags; /* What kludges to activate */
+    int scroll_everywhere; /* Whether scrolling is limited to the scrollbars only */
 
     int need_help; /* Print usage and exit */
 

--- a/stalonetray.xml.in
+++ b/stalonetray.xml.in
@@ -354,6 +354,14 @@
   </varlistentry>
 
   <varlistentry>
+  <term><option>--scroll-everywhere</option></term>
+  <term><option>scroll_everywhere</option> <optional><replaceable>bool</replaceable></optional></term>
+  <listitem><para>Enable scrolling outside of the scrollbars too. Default value:
+  <userinput>false</userinput>.
+  </para></listitem>
+  </varlistentry>
+
+  <varlistentry>
   <term><option>--skip-taskbar</option></term>
   <term><option>skip_taskbar</option> <optional><replaceable>bool</replaceable></optional></term>
   <listitem><para>Hide tray`s window from the taskbar. Default value:


### PR DESCRIPTION
I was missing a feature to allow scrolling without needing to hit the small bars in the tray, this PR adds this. What I am not sure about is, if there is a better way than `XGrabInput` to get the ButtonRelease events.