### PR TITLE
feat: reorder tray icons through drag-n-drop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["14.2", "14.3", "15.0"]
+        version: ["14.2", "14.3"]
 
     steps:
       - name: Checkout source code

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'stalonetray',
   'c',
-  version: '1.0.3',
+  version: '1.1.0',
   default_options: ['warning_level=3', 'c_std=gnu23'],
   meson_version: '>=1.1.0',
 )

--- a/src/drag.c
+++ b/src/drag.c
@@ -22,6 +22,7 @@
 #include "layout.h"
 #include "settings.h"
 #include "tray.h"
+#include "xutils.h"
 
 /* Locks that may be combined with the user-chosen modifier and that we must
  * grab for explicitly, since XGrabButton matches modifier masks exactly.
@@ -41,15 +42,15 @@ static struct {
     int anchor_root_x, anchor_root_y;
     /* src->l.icn_rect position when the drag started (tray-relative). */
     int anchor_icn_x, anchor_icn_y;
-    /* The icon whose slot src has most recently been spliced past; debounces
-     * the splice so we don't thrash the list on every motion event. */
-    struct TrayIcon *last_target;
     Cursor cursor;
+    /* Marker showing the slot src will drop into. */
+    Window indicator;
 } drag_state;
 
 static struct TrayIcon *drag_pick_target(int tray_x, int tray_y);
 static int drag_pick_target_cbk(struct TrayIcon *ti);
 static void drag_follow_cursor(int root_x, int root_y);
+static void drag_update_indicator(void);
 static void drag_finish(void);
 
 /* Closure for drag_pick_target. */
@@ -59,12 +60,19 @@ static struct {
 
 void drag_init(void)
 {
+    XColor color;
     drag_state.active = 0;
     drag_state.src = NULL;
-    drag_state.last_target = NULL;
     drag_state.cursor = None;
-    if (settings.drag_reorder)
-        drag_state.cursor = XCreateFontCursor(tray_data.dpy, XC_fleur);
+    drag_state.indicator = None;
+    if (!settings.drag_reorder) return;
+    drag_state.cursor = XCreateFontCursor(tray_data.dpy, XC_fleur);
+    /* A lightweight always-allocated marker window, shown only while dragging.
+     * It is sized and positioned per-drag in drag_update_indicator(). */
+    if (!x11_parse_color(tray_data.dpy, "gold", &color))
+        x11_parse_color(tray_data.dpy, "yellow", &color);
+    drag_state.indicator = XCreateSimpleWindow(tray_data.dpy, tray_data.tray,
+        0, 0, 1, 1, 0, color.pixel, color.pixel);
 }
 
 void drag_install_grab(struct TrayIcon *ti)
@@ -93,8 +101,9 @@ void drag_forget_icon(struct TrayIcon *ti)
     if (drag_state.src == ti) {
         drag_state.active = 0;
         drag_state.src = NULL;
+        if (drag_state.indicator != None)
+            XUnmapWindow(tray_data.dpy, drag_state.indicator);
     }
-    if (drag_state.last_target == ti) drag_state.last_target = NULL;
 }
 
 void drag_handle_event(XEvent ev)
@@ -114,13 +123,18 @@ void drag_handle_event(XEvent ev)
         if (ti == NULL || !ti->is_visible || !ti->is_layed_out) break;
         drag_state.active = 1;
         drag_state.src = ti;
-        drag_state.last_target = NULL;
         drag_state.anchor_root_x = ev.xbutton.x_root;
         drag_state.anchor_root_y = ev.xbutton.y_root;
         drag_state.anchor_icn_x = ti->l.icn_rect.x;
         drag_state.anchor_icn_y = ti->l.icn_rect.y;
-        /* Float above peers for the duration of the drag. The mid-parent is
-         * restored to its lowered position in drag_finish(). */
+        /* Show the landing marker, then float the icon above everything (incl.
+         * the marker). Moves during the drag don't restack, so this ordering
+         * holds for the whole gesture. */
+        drag_update_indicator();
+        if (drag_state.indicator != None) {
+            XMapWindow(tray_data.dpy, drag_state.indicator);
+            XRaiseWindow(tray_data.dpy, drag_state.indicator);
+        }
         XRaiseWindow(tray_data.dpy, ti->mid_parent);
         LOG_TRACE(("drag start: icon 0x%lx at (%d,%d)\n", ti->wid,
             ti->l.icn_rect.x, ti->l.icn_rect.y));
@@ -134,7 +148,6 @@ void drag_handle_event(XEvent ev)
         tray_y = ev.xmotion.y_root - tray_data.xsh.y;
         target = drag_pick_target(tray_x, tray_y);
         if (target == NULL || target == drag_state.src) break;
-        if (target == drag_state.last_target) break;
         /* Decide whether src lands before or after target by comparing the
          * pointer to the target's midpoint along the major axis. */
         {
@@ -150,10 +163,15 @@ void drag_handle_event(XEvent ev)
              * splicing past the tail moves src to the end. */
             before = past_mid ? target->next : target;
             if (before == drag_state.src) before = before->next;
+            /* Debounce on the resulting position, not on target identity:
+             * src is already where it belongs when its successor is `before`.
+             * This lets crossing a neighbour's midpoint re-trigger the splice
+             * without first leaving that neighbour's rect. */
+            if (drag_state.src->next == before) break;
             icon_list_move_before(drag_state.src, before);
         }
-        drag_state.last_target = target;
         layout_relayout_in_list_order();
+        drag_update_indicator();
         /* Non-forced: only icons whose slot actually moved get repositioned,
          * which keeps the rest of the tray from flickering on each shuffle. */
         embedder_update_positions(False);
@@ -201,13 +219,29 @@ static void drag_follow_cursor(int root_x, int root_y)
         new_icn_x + inner_x, new_icn_y + inner_y);
 }
 
+/* Size and position the landing marker to mirror src's reserved slot. The
+ * slot is read from src->l.icn_rect, which the relayout keeps pointing at
+ * where src will drop (even though mid_parent is off following the cursor). */
+static void drag_update_indicator(void)
+{
+    struct TrayIcon *ti = drag_state.src;
+    int inner_x, inner_y;
+    if (drag_state.indicator == None || ti == NULL) return;
+    inner_x = (ti->l.icn_rect.w - ti->l.wnd_sz.x) / 2;
+    inner_y = (ti->l.icn_rect.h - ti->l.wnd_sz.y) / 2;
+    XMoveResizeWindow(tray_data.dpy, drag_state.indicator,
+        ti->l.icn_rect.x + inner_x, ti->l.icn_rect.y + inner_y,
+        ti->l.wnd_sz.x, ti->l.wnd_sz.y);
+}
+
 static void drag_finish(void)
 {
     struct TrayIcon *src = drag_state.src;
     LOG_TRACE(("drag end: icon 0x%lx\n", src ? src->wid : None));
+    if (drag_state.indicator != None)
+        XUnmapWindow(tray_data.dpy, drag_state.indicator);
     drag_state.active = 0;
     drag_state.src = NULL;
-    drag_state.last_target = NULL;
     /* mid_parent has been tracking the cursor; mark it dirty so the embedder
      * snaps it back to its slot, while peers (already in place) stay put. */
     if (src != NULL) src->is_updated = True;

--- a/src/drag.c
+++ b/src/drag.c
@@ -1,0 +1,220 @@
+/* -------------------------------
+ * vim:tabstop=4:shiftwidth=4
+ * drag.c
+ * -------------------------------
+ * Drag-to-reorder tray icons.
+ *
+ * We arm a passive XGrabButton(Button1 + modifier) on each icon's mid-parent.
+ * When the user presses Button1 with the modifier, X promotes the grab to an
+ * active one; we then track motion until ButtonRelease, splicing the icon list
+ * to follow the cursor and relaying out peers in real time.
+ * -------------------------------*/
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/cursorfont.h>
+
+#include "common.h"
+#include "debug.h"
+#include "drag.h"
+#include "embed.h"
+#include "icons.h"
+#include "layout.h"
+#include "settings.h"
+#include "tray.h"
+
+/* Locks that may be combined with the user-chosen modifier and that we must
+ * grab for explicitly, since XGrabButton matches modifier masks exactly.
+ * The list mirrors what most X11 apps do: CapsLock, NumLock (Mod2 by default),
+ * and the two together. */
+static const unsigned int IGNORED_LOCKS[] = {
+    0,
+    LockMask,
+    Mod2Mask,
+    LockMask | Mod2Mask,
+};
+
+static struct {
+    int active;
+    struct TrayIcon *src;
+    /* Pointer position when the drag started (root coords). */
+    int anchor_root_x, anchor_root_y;
+    /* src->l.icn_rect position when the drag started (tray-relative). */
+    int anchor_icn_x, anchor_icn_y;
+    /* The icon whose slot src has most recently been spliced past; debounces
+     * the splice so we don't thrash the list on every motion event. */
+    struct TrayIcon *last_target;
+    Cursor cursor;
+} drag_state;
+
+static struct TrayIcon *drag_pick_target(int tray_x, int tray_y);
+static int drag_pick_target_cbk(struct TrayIcon *ti);
+static void drag_follow_cursor(int root_x, int root_y);
+static void drag_finish(void);
+
+/* Closure for drag_pick_target. */
+static struct {
+    int x, y;
+} pick_pt;
+
+void drag_init(void)
+{
+    drag_state.active = 0;
+    drag_state.src = NULL;
+    drag_state.last_target = NULL;
+    drag_state.cursor = None;
+    if (settings.drag_reorder)
+        drag_state.cursor = XCreateFontCursor(tray_data.dpy, XC_fleur);
+}
+
+void drag_install_grab(struct TrayIcon *ti)
+{
+    unsigned int i;
+    if (!settings.drag_reorder || settings.drag_modifier == 0) return;
+    if (ti->mid_parent == None) return;
+    /* The passive grab activates only when the modifier+button match; the
+     * icon's own client keeps receiving unmodified clicks. */
+    XSelectInput(tray_data.dpy, ti->mid_parent,
+        ButtonPressMask | ButtonReleaseMask | ButtonMotionMask);
+    for (i = 0; i < sizeof(IGNORED_LOCKS) / sizeof(IGNORED_LOCKS[0]); i++)
+        XGrabButton(tray_data.dpy, Button1,
+            settings.drag_modifier | IGNORED_LOCKS[i], ti->mid_parent,
+            False, ButtonPressMask | ButtonReleaseMask | ButtonMotionMask,
+            GrabModeAsync, GrabModeAsync, None, drag_state.cursor);
+}
+
+int drag_icon_is_floating(struct TrayIcon *ti)
+{
+    return drag_state.active && drag_state.src == ti;
+}
+
+void drag_forget_icon(struct TrayIcon *ti)
+{
+    if (drag_state.src == ti) {
+        drag_state.active = 0;
+        drag_state.src = NULL;
+    }
+    if (drag_state.last_target == ti) drag_state.last_target = NULL;
+}
+
+void drag_handle_event(XEvent ev)
+{
+    struct TrayIcon *ti, *target;
+    int tray_x, tray_y;
+
+    switch (ev.type) {
+    case ButtonPress:
+        if (drag_state.active) break;
+        if (ev.xbutton.button != Button1) break;
+        if (settings.drag_modifier == 0
+            || (ev.xbutton.state & settings.drag_modifier)
+                != settings.drag_modifier)
+            break;
+        ti = icon_list_find_by_mid_parent(ev.xbutton.window);
+        if (ti == NULL || !ti->is_visible || !ti->is_layed_out) break;
+        drag_state.active = 1;
+        drag_state.src = ti;
+        drag_state.last_target = NULL;
+        drag_state.anchor_root_x = ev.xbutton.x_root;
+        drag_state.anchor_root_y = ev.xbutton.y_root;
+        drag_state.anchor_icn_x = ti->l.icn_rect.x;
+        drag_state.anchor_icn_y = ti->l.icn_rect.y;
+        /* Float above peers for the duration of the drag. The mid-parent is
+         * restored to its lowered position in drag_finish(). */
+        XRaiseWindow(tray_data.dpy, ti->mid_parent);
+        LOG_TRACE(("drag start: icon 0x%lx at (%d,%d)\n", ti->wid,
+            ti->l.icn_rect.x, ti->l.icn_rect.y));
+        break;
+
+    case MotionNotify:
+        if (!drag_state.active) break;
+        drag_follow_cursor(ev.xmotion.x_root, ev.xmotion.y_root);
+        /* Translate pointer to tray-relative coordinates and pick a target. */
+        tray_x = ev.xmotion.x_root - tray_data.xsh.x;
+        tray_y = ev.xmotion.y_root - tray_data.xsh.y;
+        target = drag_pick_target(tray_x, tray_y);
+        if (target == NULL || target == drag_state.src) break;
+        if (target == drag_state.last_target) break;
+        /* Decide whether src lands before or after target by comparing the
+         * pointer to the target's midpoint along the major axis. */
+        {
+            int past_mid;
+            struct TrayIcon *before;
+            if (settings.vertical)
+                past_mid = tray_y
+                    >= target->l.icn_rect.y + target->l.icn_rect.h / 2;
+            else
+                past_mid = tray_x
+                    >= target->l.icn_rect.x + target->l.icn_rect.w / 2;
+            /* Use raw next/prev (not icon_list_next, which wraps) so that
+             * splicing past the tail moves src to the end. */
+            before = past_mid ? target->next : target;
+            if (before == drag_state.src) before = before->next;
+            icon_list_move_before(drag_state.src, before);
+        }
+        drag_state.last_target = target;
+        layout_relayout_in_list_order();
+        /* Non-forced: only icons whose slot actually moved get repositioned,
+         * which keeps the rest of the tray from flickering on each shuffle. */
+        embedder_update_positions(False);
+        break;
+
+    case ButtonRelease:
+        if (!drag_state.active) break;
+        if (ev.xbutton.button != Button1) break;
+        drag_finish();
+        break;
+    }
+}
+
+/* Return the visible icon (other than src) whose icn_rect contains
+ * (tray_x, tray_y), or NULL. */
+static struct TrayIcon *drag_pick_target(int tray_x, int tray_y)
+{
+    pick_pt.x = tray_x;
+    pick_pt.y = tray_y;
+    return icon_list_advanced_find(&drag_pick_target_cbk);
+}
+
+static int drag_pick_target_cbk(struct TrayIcon *ti)
+{
+    if (ti == drag_state.src) return NO_MATCH;
+    if (!ti->is_visible || !ti->is_layed_out) return NO_MATCH;
+    if (pick_pt.x >= ti->l.icn_rect.x
+        && pick_pt.x < ti->l.icn_rect.x + ti->l.icn_rect.w
+        && pick_pt.y >= ti->l.icn_rect.y
+        && pick_pt.y < ti->l.icn_rect.y + ti->l.icn_rect.h)
+        return MATCH;
+    return NO_MATCH;
+}
+
+static void drag_follow_cursor(int root_x, int root_y)
+{
+    struct TrayIcon *ti = drag_state.src;
+    int new_icn_x = drag_state.anchor_icn_x + (root_x - drag_state.anchor_root_x);
+    int new_icn_y = drag_state.anchor_icn_y + (root_y - drag_state.anchor_root_y);
+    /* mid_parent is centered inside the icn_rect by the same offset embed.c
+     * applies in CALC_INNER_POS. */
+    int inner_x = (ti->l.icn_rect.w - ti->l.wnd_sz.x) / 2;
+    int inner_y = (ti->l.icn_rect.h - ti->l.wnd_sz.y) / 2;
+    XMoveWindow(tray_data.dpy, ti->mid_parent,
+        new_icn_x + inner_x, new_icn_y + inner_y);
+}
+
+static void drag_finish(void)
+{
+    struct TrayIcon *src = drag_state.src;
+    LOG_TRACE(("drag end: icon 0x%lx\n", src ? src->wid : None));
+    drag_state.active = 0;
+    drag_state.src = NULL;
+    drag_state.last_target = NULL;
+    /* mid_parent has been tracking the cursor; mark it dirty so the embedder
+     * snaps it back to its slot, while peers (already in place) stay put. */
+    if (src != NULL) src->is_updated = True;
+    layout_relayout_in_list_order();
+    embedder_update_positions(False);
+    if (src != NULL && src->mid_parent != None)
+        XLowerWindow(tray_data.dpy, src->mid_parent);
+    tray_update_window_props();
+}
+

--- a/src/drag.h
+++ b/src/drag.h
@@ -1,0 +1,36 @@
+/* -------------------------------
+ * vim:tabstop=4:shiftwidth=4
+ * drag.h
+ * -------------------------------
+ * Drag-to-reorder tray icons.
+ * -------------------------------*/
+
+#ifndef _DRAG_H_
+#define _DRAG_H_
+
+#include <X11/Xlib.h>
+
+#include "icons.h"
+
+/* One-time setup. Safe to call without an active drag in flight. */
+void drag_init(void);
+
+/* Arm the passive Button1+modifier grab on ti's mid-parent. Called from
+ * embedder_embed once mid_parent exists. No-op when drag_reorder is off
+ * or no modifier is configured. */
+void drag_install_grab(struct TrayIcon *ti);
+
+/* Dispatch button/motion events that belong to the drag interaction.
+ * Plugs into the main event loop next to scrollbars_handle_event. */
+void drag_handle_event(XEvent ev);
+
+/* True while ti is the icon currently following the cursor. The embedder
+ * consults this to avoid overwriting the cursor-tracking position with the
+ * grid-derived one during a drag. */
+int drag_icon_is_floating(struct TrayIcon *ti);
+
+/* Forget any in-flight drag involving ti. Called when ti is about to be
+ * freed so we don't dereference it later. */
+void drag_forget_icon(struct TrayIcon *ti);
+
+#endif

--- a/src/embed.c
+++ b/src/embed.c
@@ -20,6 +20,7 @@
 
 #include "common.h"
 #include "debug.h"
+#include "drag.h"
 #include "icons.h"
 #include "settings.h"
 #include "tray.h"
@@ -103,6 +104,7 @@ int embedder_embed(struct TrayIcon *ti)
     /* mid-parent must be lowered so that it does not osbcure
      * scollbar windows */
     XLowerWindow(tray_data.dpy, ti->mid_parent);
+    drag_install_grab(ti);
     if (!x11_ok()) RETURN_STATUS(FAILURE);
 #ifndef DELAY_EMBEDDING_CONFIRMATION
     /* 5. Send message confirming embedding */
@@ -212,6 +214,9 @@ static int embedder_update_window_position(struct TrayIcon *ti)
     int x, y;
     /* Ignore hidden icons */
     if (!ti->is_visible) return NO_MATCH;
+    /* The icon currently following the cursor positions itself; the grid
+     * value is for after-release snapping only. */
+    if (drag_icon_is_floating(ti)) return NO_MATCH;
     /* Update only those icons that do want it (everyone if update was forced)
      */
     if (!update_forced && !ti->is_updated && !ti->is_resized

--- a/src/icons.c
+++ b/src/icons.c
@@ -159,6 +159,44 @@ struct TrayIcon *icon_list_find_ex(Window wid)
     return NULL;
 }
 
+struct TrayIcon *icon_list_find_by_mid_parent(Window wid)
+{
+    struct TrayIcon *tmp;
+    if (wid == None) return NULL;
+    for (tmp = icons_head; tmp != NULL; tmp = tmp->next)
+        if (tmp->mid_parent == wid) return tmp;
+    return NULL;
+}
+
+void icon_list_move_before(struct TrayIcon *ti, struct TrayIcon *target)
+{
+    struct TrayIcon *tail;
+    if (ti == NULL || ti == target) return;
+    LIST_DEL_ITEM(icons_head, ti);
+    /* LIST_INSERT_AFTER in list.h skips fixing up i->next->prev when
+     * inserting in the middle of the list, so we splice by hand to keep both
+     * directions consistent. */
+    if (target != NULL) {
+        ti->prev = target->prev;
+        ti->next = target;
+        if (target->prev != NULL)
+            target->prev->next = ti;
+        else
+            icons_head = ti;
+        target->prev = ti;
+    } else if (icons_head == NULL) {
+        ti->prev = NULL;
+        ti->next = NULL;
+        icons_head = ti;
+    } else {
+        for (tail = icons_head; tail->next != NULL; tail = tail->next)
+            ;
+        ti->prev = tail;
+        ti->next = NULL;
+        tail->next = ti;
+    }
+}
+
 int icon_list_clean()
 {
     struct TrayIcon *tmp;

--- a/src/icons.h
+++ b/src/icons.h
@@ -52,6 +52,8 @@ struct TrayIcon {
     struct Layout l; /* Layout info */
 };
 
+extern struct TrayIcon *icons_head;
+
 /* Typedef for comparison function */
 typedef int (*IconCmpFunc)(struct TrayIcon *, struct TrayIcon *);
 
@@ -113,5 +115,11 @@ struct TrayIcon *icon_list_find(Window w);
 
 /* Find the icon with wid == w or parent wid == w */
 struct TrayIcon *icon_list_find_ex(Window w);
+
+/* Find the icon whose mid_parent == w */
+struct TrayIcon *icon_list_find_by_mid_parent(Window w);
+
+/* Splice ti before target in the list; if target is NULL, splice to the end */
+void icon_list_move_before(struct TrayIcon *ti, struct TrayIcon *target);
 
 #endif

--- a/src/layout.c
+++ b/src/layout.c
@@ -575,3 +575,72 @@ int layout_unset_flag(struct TrayIcon *ti)
     ti->is_layed_out = 0;
     return NO_MATCH;
 }
+
+int layout_relayout_in_list_order(void)
+{
+    /* Lay icons out by walking the list and assigning sequential grid slots.
+     * grid_find_placement is intentionally bypassed: its placement search
+     * would mark every icon as updated on every call (because grid_add resets
+     * grd_rect.x to -1), which causes flicker and unnecessary X traffic
+     * during a drag. Here we set is_updated only when the slot actually moved. */
+    struct TrayIcon *ti;
+    int cur_x = 0, cur_y = 0, row_h = 0;
+    int max_x, max_y;
+
+    /* grd_rect lives in a coord system where x is the major axis (along which
+     * icons grow) and y is the minor; layout_translate_to_window swaps these
+     * for vertical trays. The max_* expressions below mirror the convention
+     * used in icon_placement_create. */
+    max_x = settings.scrollbars_mode & SB_MODE_HORZ
+        ? INT_MAX
+        : (settings.vertical ? settings.max_tray_dims.y
+                             : settings.max_tray_dims.x)
+            / settings.slot_size.x;
+    max_y = settings.scrollbars_mode & SB_MODE_VERT
+        ? INT_MAX
+        : (settings.vertical ? settings.max_tray_dims.x
+                             : settings.max_tray_dims.y)
+            / settings.slot_size.y;
+
+    grid_sz.x = 0;
+    grid_sz.y = 0;
+
+    for (ti = icons_head; ti != NULL; ti = ti->next) {
+        struct Rect old_grd;
+        int was_layed_out;
+        if (!ti->is_visible) {
+            ti->is_layed_out = 0;
+            continue;
+        }
+        old_grd = ti->l.grd_rect;
+        was_layed_out = ti->is_layed_out;
+        grid_translate_from_window(ti);
+        /* Wrap before placing if the icon wouldn't fit on the current row. */
+        if (cur_x + ti->l.grd_rect.w > max_x) {
+            cur_x = 0;
+            cur_y += row_h > 0 ? row_h : 1;
+            row_h = 0;
+        }
+        /* Hard cap: drop icons that would land past the secondary limit.
+         * Pre-existing layouts wouldn't hit this, but a degenerate config
+         * shouldn't push icons off-screen silently. */
+        if (cur_y + ti->l.grd_rect.h > max_y) {
+            ti->is_layed_out = 0;
+            continue;
+        }
+        ti->l.grd_rect.x = cur_x;
+        ti->l.grd_rect.y = cur_y;
+        ti->is_layed_out = 1;
+        ti->is_updated = ti->is_updated || !was_layed_out
+            || old_grd.x != cur_x || old_grd.y != cur_y;
+        if (ti->l.grd_rect.h > row_h) row_h = ti->l.grd_rect.h;
+        cur_x += ti->l.grd_rect.w;
+        if (cur_x > grid_sz.x) grid_sz.x = cur_x;
+        if (cur_y + ti->l.grd_rect.h > grid_sz.y)
+            grid_sz.y = cur_y + ti->l.grd_rect.h;
+    }
+
+    icon_list_forall(&layout_translate_to_window);
+    LOG_TRACE(("relayout in list order: grid size %dx%d\n", grid_sz.x, grid_sz.y));
+    return SUCCESS;
+}

--- a/src/layout.h
+++ b/src/layout.h
@@ -54,6 +54,10 @@ void layout_get_size(int *width, int *height);
 /* Translate grid coordinates into window coordinates */
 int layout_translate_to_window(struct TrayIcon *ti);
 
+/* Re-lay out every visible icon from scratch following list order.
+ * Used by drag-to-reorder to commit the new sequence. */
+int layout_relayout_in_list_order(void);
+
 /* Return next icon in tab chain */
 struct TrayIcon *layout_next(struct TrayIcon *current);
 

--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,7 @@
 
 #include "common.h"
 #include "debug.h"
+#include "drag.h"
 #include "embed.h"
 #include "icons.h"
 #include "layout.h"
@@ -222,6 +223,7 @@ void remove_icon(Window w)
     /* Ignore false alarms */
     if ((ti = icon_list_find(w)) == NULL) return;
     dump_tray_status();
+    drag_forget_icon(ti);
     embedder_unembed(ti);
     xembed_unembed(ti);
     layout_remove(ti);
@@ -789,6 +791,7 @@ int tray_main(int argc, char **argv)
     kde_tray_init(tray_data.dpy);
 #endif
     xembed_init();
+    drag_init();
 #ifdef _ST_WITH_NATIVE_KDE
     kde_icons_update();
 #endif
@@ -808,6 +811,7 @@ int tray_main(int argc, char **argv)
             XNextEvent(tray_data.dpy, &ev);
             xembed_handle_event(ev);
             scrollbars_handle_event(ev);
+            drag_handle_event(ev);
             switch (ev.type) {
             case VisibilityNotify:
                 LOG_TRACE(("VisibilityNotify (0x%lx, state=%d)\n",

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,6 @@
 project_sources += [
   'src/debug.c',
+  'src/drag.c',
   'src/embed.c',
   'src/icons.c',
   'src/image.c',

--- a/src/settings.c
+++ b/src/settings.c
@@ -85,6 +85,8 @@ void init_default_settings(void)
     settings.remote_click_pos.y = REMOTE_CLICK_POS_DEFAULT;
     settings.ignored_classes = NULL;
     settings.scroll_everywhere = 0;
+    settings.drag_reorder = 1;
+    settings.drag_modifier = Mod1Mask;
 #ifdef DELAY_EMBEDDING_CONFIRMATION
     settings.confirmation_delay = 3;
 #endif
@@ -259,6 +261,29 @@ int parse_strut_mode(int, const char **argv, void **references, int silent)
         return FAILURE;
     }
 
+    return SUCCESS;
+}
+
+/* Parse X11 modifier name (alt, shift, ctrl, super, none) into a mask. */
+int parse_modifier(int, const char **argv, void **references, int silent)
+{
+    unsigned int *mask = (unsigned int *) references[0];
+    const char *name = argv[0];
+
+    if (!strcasecmp(name, "alt") || !strcasecmp(name, "mod1"))
+        *mask = Mod1Mask;
+    else if (!strcasecmp(name, "shift"))
+        *mask = ShiftMask;
+    else if (!strcasecmp(name, "ctrl") || !strcasecmp(name, "control"))
+        *mask = ControlMask;
+    else if (!strcasecmp(name, "super") || !strcasecmp(name, "mod4"))
+        *mask = Mod4Mask;
+    else if (!strcasecmp(name, "none"))
+        *mask = 0;
+    else {
+        PARSING_ERROR("alt, shift, ctrl, super, or none expected", name);
+        return FAILURE;
+    }
     return SUCCESS;
 }
 
@@ -933,6 +958,38 @@ struct Param params[] = {
     },
     {
         .short_name = NULL,
+        .long_name = "--drag-reorder",
+        .rc_name = "drag_reorder",
+        .references = { (void *) &settings.drag_reorder },
+
+        .pass = 1,
+
+        .min_argc = 0,
+        .max_argc = 1,
+
+        .default_argc = 1,
+        .default_argv = {"true"},
+
+        .parser = (param_parser_t) &parse_bool
+    },
+    {
+        .short_name = NULL,
+        .long_name = "--drag-modifier",
+        .rc_name = "drag_modifier",
+        .references = { (void *) &settings.drag_modifier },
+
+        .pass = 1,
+
+        .min_argc = 1,
+        .max_argc = 1,
+
+        .default_argc = 0,
+        .default_argv = NULL,
+
+        .parser = (param_parser_t) &parse_modifier
+    },
+    {
+        .short_name = NULL,
         .long_name = "--skip-taskbar",
         .rc_name = "skip_taskbar",
         .references = { (void *) &settings.skip_taskbar },
@@ -1286,6 +1343,9 @@ void usage(char *progname)
         "    --scrollbars-step <n>       set scrollbar step to n pixels\n"
         "    --scrollbars-size <n>       set scrollbar size to n pixels\n"
         "    --scroll-everywhere         enable scrolling outside of the scrollbars too\n"
+        "    --drag-reorder [<bool>]     allow dragging icons to reorder them (default: true)\n"
+        "    --drag-modifier <mod>       modifier that enables drag: alt (default),\n"
+        "                                shift, ctrl, super, or none\n"
         "    --slot-size <w>[x<h>]       set icon slot size in pixels\n"
         "                                if omitted, hight is set equal to width\n"
         "    --skip-taskbar              hide tray`s window from the taskbar\n"

--- a/src/settings.h
+++ b/src/settings.h
@@ -39,6 +39,8 @@ struct Settings {
     int dockapp_mode; /* Activate dockapp mode */
     int kludge_flags; /* What kludges to activate */
     int scroll_everywhere; /* Whether scrolling is limited to the scrollbars only */
+    int drag_reorder; /* Allow dragging icons to reorder them */
+    unsigned int drag_modifier; /* X11 modifier mask gating the drag (e.g. Mod1Mask) */
 
     int need_help; /* Print usage and exit */
 

--- a/stalonetray.xml.in
+++ b/stalonetray.xml.in
@@ -371,6 +371,27 @@
   </varlistentry>
 
   <varlistentry>
+  <term><option>--drag-reorder</option> <optional><replaceable>bool</replaceable></optional></term>
+  <term><option>drag_reorder</option> <optional><replaceable>bool</replaceable></optional></term>
+  <listitem><para>Allow reordering icons by holding the drag modifier and
+  dragging them with the left mouse button. Default value:
+  <userinput>true</userinput>.
+  </para></listitem>
+  </varlistentry>
+
+  <varlistentry>
+  <term><option>--drag-modifier</option> <replaceable>mod</replaceable></term>
+  <term><option>drag_modifier</option> <replaceable>mod</replaceable></term>
+  <listitem><para>Keyboard modifier that must be held to start a drag.
+  Accepted values: <userinput>alt</userinput>, <userinput>shift</userinput>,
+  <userinput>ctrl</userinput>, <userinput>super</userinput>, or
+  <userinput>none</userinput>. Default value: <userinput>alt</userinput>.
+  Setting this to <userinput>none</userinput> lets any Button1 drag start
+  a reorder, which will also fire a click on the icon.
+  </para></listitem>
+  </varlistentry>
+
+  <varlistentry>
   <term><option>--skip-taskbar</option></term>
   <term><option>skip_taskbar</option> <optional><replaceable>bool</replaceable></optional></term>
   <listitem><para>Hide tray`s window from the taskbar. Default value:

--- a/stalonetrayrc.sample
+++ b/stalonetrayrc.sample
@@ -102,6 +102,13 @@ scrollbars none
 # slot_size <int>            # specifies size of icon slot, defaults to
                              # icon_size.
 
+# drag_reorder [<bool>]      # allow dragging icons to reorder them
+# drag_reorder true
+
+# drag_modifier <mod>        # modifier that enables drag: alt (default),
+#                            # shift, ctrl, super, or none
+# drag_modifier alt
+
 # skip_taskbar [<bool>]      # hide tray`s window from the taskbar
 skip_taskbar true
 


### PR DESCRIPTION
Allow reordering tray icons by dragging and dropping them while holding a
configurable modifier key (defaults to Alt). A gold indicator will be shown
where the icon will land on the tray.

- **feat: allow drag-n-drop reordering of icons**
- **ci: temporarily disable building on freebsd 15.0**
- **feat: show gold indicator when dragging icons**
