### PR TITLE
feat: react to monitor changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        featureset: ["base", "xinerama", "xpm", "native_kde", "all", "debug"]
+        featureset: ["base", "xinerama", "randr", "xpm", "native_kde", "all", "debug"]
 
     steps:
       - name: Checkout source code
@@ -30,7 +30,8 @@ jobs:
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: >
-            xsltproc docbook-xsl libxpm-dev libx11-dev libxinerama-dev meson
+            xsltproc docbook-xsl libxpm-dev libx11-dev libxinerama-dev
+            libxrandr-dev meson
 
       - name: Set up build directory
         run: >
@@ -40,11 +41,13 @@ jobs:
           elif [ "${{ matrix.featureset }}" = "all" ]; then
             echo "== Enabling all features =="
             meson setup --buildtype release build -D c_std=gnu2x \
-              -D xinerama=enabled -D xpm=enabled -D native_kde=enabled
+              -D xinerama=enabled -D randr=enabled -D xpm=enabled \
+              -D native_kde=enabled
           elif [ "${{ matrix.featureset }}" = "debug" ]; then
             echo "== Debug build with all features enabled =="
             meson setup --buildtype debug build -D c_std=gnu2x \
-              -D xinerama=enabled -D xpm=enabled -D native_kde=enabled \
+              -D xinerama=enabled -D randr=enabled -D xpm=enabled \
+              -D native_kde=enabled \
               -D trace_events=true -D delay_embedding_confirmation=true \
               -D dump_window_information=true -D exit_gracefully=true
           else
@@ -104,15 +107,15 @@ jobs:
             echo "FreeBSD: { url: ${repoURL} }" > "$repoFile"
             IGNORE_OSVERSION=yes pkg update -f
 
-            pkg install -y pkgconf meson libX11 libXpm libXinerama docbook-xsl \
-              libxslt
+            pkg install -y pkgconf meson libX11 libXpm libXinerama libXrandr \
+              docbook-xsl libxslt
           run: |
             echo "== Basic build =="
             meson setup --buildtype release build
             meson compile -C build stalonetray
             meson compile -C build manpage
 
-            for feature in xinerama xpm native_kde; do
+            for feature in xinerama randr xpm native_kde; do
               echo "== Building with $feature enabled =="
               meson setup --wipe build -D $feature=enabled
               meson compile -C build stalonetray
@@ -121,6 +124,7 @@ jobs:
 
             echo "== Building with all features enabled =="
             meson setup --wipe build \
-              -D xinerama=enabled -D xpm=enabled -D native_kde=enabled
+              -D xinerama=enabled -D randr=enabled -D xpm=enabled \
+              -D native_kde=enabled
             meson compile -C build stalonetray
             meson compile -C build manpage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,8 @@ jobs:
           sudo rm -f /var/lib/man-db/auto-update
           sudo apt-get update
           sudo apt-get install -y \
-            xsltproc docbook-xsl libxpm-dev libx11-dev libxinerama-dev
+            xsltproc docbook-xsl libxpm-dev libx11-dev libxinerama-dev \
+            libxrandr-dev
 
           pip install 'meson>=1.5.0'
           meson setup --buildtype release _build -D c_std=gnu2x

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 
 Stalonetray is a STAnd-aLONE system TRAY (notification area) for Unix desktops
 using the X11 windowing system. It has minimal default build and run-time
-dependencies: the Xlib and libXinerama, though you could do away with the
-latter by disabling a feature for even more minimalism. Stalonetray runs under
-virtually any window manager.
+dependencies: the Xlib, libXinerama and libXRandR, though you could do away
+with the latter two by disabling features for even more minimalism. Stalonetray
+runs under virtually any window manager.
 
 To start using stalonetray, just copy `stalonetrayrc.sample` to
 `~/.stalonetrayrc` or to `$XDG_CONFIG_HOME/stalonetrayrc`. It is well-commented
 and should suffice for a quick start.
 
-Note that some features are disabled by default and may not work out of the
-box, depending on how stalonetray was built by the package maintainer. See the
+Note that some features may be disabled by default and not work out of the box,
+depending on how stalonetray was built by the package maintainer. See the
 "Building from source" section below if you want to compile it yourself with
 the features you need.
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'stalonetray',
   'c',
-  version: '1.2.0',
+  version: '1.3.0',
   default_options: ['warning_level=3', 'c_std=gnu23'],
   meson_version: '>=1.1.0',
 )

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ project_sources = []
 dependencies = {
   'x11': dependency('x11', required: true),
   'xinerama': dependency('xinerama', required: get_option('xinerama')),
+  'randr': dependency('xrandr', required: get_option('randr')),
   'xpm': dependency('xpm', required: get_option('xpm')),
 }
 
@@ -36,6 +37,11 @@ feature_list = []
 if get_option('xinerama').enabled()
   build_args += ['-D_ST_WITH_XINERAMA']
   feature_list += ['xinerama']
+endif
+
+if get_option('randr').enabled()
+  build_args += ['-D_ST_WITH_XRANDR']
+  feature_list += ['randr']
 endif
 
 if get_option('xpm').enabled()

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,12 @@ subdir('src')
 
 feature_list = []
 
+# RandR only drives runtime reaction to monitor changes by re-querying
+# Xinerama, so it is meaningless on its own.
+if get_option('randr').enabled() and not get_option('xinerama').enabled()
+  error('randr support requires xinerama support')
+endif
+
 if get_option('xinerama').enabled()
   build_args += ['-D_ST_WITH_XINERAMA']
   feature_list += ['xinerama']

--- a/meson.options
+++ b/meson.options
@@ -1,5 +1,7 @@
 option('xinerama', type: 'feature', value: 'enabled',
   description: 'Enable Xinerama support for multiple monitors')
+option('randr', type: 'feature', value: 'enabled',
+  description: 'Enable XRandR support to react to monitor changes at runtime')
 option('xpm', type: 'feature', value: 'auto',
   description: 'Enable XPM background support')
 option('native_kde', type: 'feature', value: 'auto',

--- a/src/main.c
+++ b/src/main.c
@@ -561,7 +561,13 @@ void client_message(XClientMessageEvent ev)
                 dump_tray_status();
 #endif
             }
-            tray_update_window_props();
+            /* The dock-confirm message is sent by us from embedder_embed and
+             * loops back through the X server; by the time we process it,
+             * tray_update_window_props has already run once (in add_icon, or
+             * in icon_track_visibility_changes for hidden->visible). Running
+             * it again here re-applies the grow-gravity shift on top of a
+             * half-applied WM state (the move processed, the resize still
+             * pending), shifting the tray by one icon width. Skip it. */
             break;
         /* Dump tray status on request */
         case STALONE_TRAY_STATUS_REQUESTED: dump_tray_status(); break;

--- a/src/main.c
+++ b/src/main.c
@@ -820,6 +820,7 @@ int tray_main(int argc, char **argv)
             xembed_handle_event(ev);
             scrollbars_handle_event(ev);
             drag_handle_event(ev);
+            xinerama_handle_event(ev);
             switch (ev.type) {
             case VisibilityNotify:
                 LOG_TRACE(("VisibilityNotify (0x%lx, state=%d)\n",

--- a/src/tray.c
+++ b/src/tray.c
@@ -48,6 +48,10 @@ void tray_init()
     tray_data.monitors = NULL;
 #endif
 
+#ifdef _ST_WITH_XRANDR
+    tray_data.randr_event_base = -1;
+#endif
+
     scrollbars_init();
 }
 

--- a/src/tray.h
+++ b/src/tray.h
@@ -117,6 +117,11 @@ struct TrayData {
     XineramaScreenInfo *monitors; /* Xinerama screens info */
 #endif
 
+#ifdef _ST_WITH_XRANDR
+    /* RandR data */
+    int randr_event_base; /* RandR event base, or -1 if RandR is unavailable */
+#endif
+
     /* XEMBED data */
     struct XEMBEDData xembed_data; /* XEMBED data */
 

--- a/src/xinerama.c
+++ b/src/xinerama.c
@@ -51,8 +51,12 @@ void xinerama_init(Display *dpy)
     {
         int error_base;
         if (XRRQueryExtension(dpy, &tray_data.randr_event_base, &error_base)) {
-            XRRSelectInput(
-                dpy, DefaultRootWindow(dpy), RRScreenChangeNotifyMask);
+            /* CRTC/output changes are needed to catch monitors being moved
+             * relative to one another, which need not change the screen size
+             * the way adding or removing a monitor does. */
+            XRRSelectInput(dpy, DefaultRootWindow(dpy),
+                RRScreenChangeNotifyMask | RRCrtcChangeNotifyMask
+                    | RROutputChangeNotifyMask);
             LOG_TRACE(("RandR active, event base %d\n",
                 tray_data.randr_event_base));
         } else {
@@ -109,14 +113,24 @@ void xinerama_handle_event(XEvent ev)
 {
 #if defined(_ST_WITH_XINERAMA) && defined(_ST_WITH_XRANDR)
     XWindowAttributes root_wa;
+    int is_screen_change, is_randr_notify;
 
-    if (tray_data.randr_event_base < 0
-        || ev.type != tray_data.randr_event_base + RRScreenChangeNotify)
+    if (tray_data.randr_event_base < 0)
         return;
 
-    LOG_TRACE(("RRScreenChangeNotify received; reconfiguring monitors\n"));
+    /* RRScreenChangeNotify covers screen-size changes (add/remove a monitor);
+     * RRNotify (CRTC/output changes) additionally covers monitors being moved
+     * relative to one another. Either way we re-derive everything. */
+    is_screen_change =
+        ev.type == tray_data.randr_event_base + RRScreenChangeNotify;
+    is_randr_notify = ev.type == tray_data.randr_event_base + RRNotify;
+    if (!is_screen_change && !is_randr_notify)
+        return;
 
-    XRRUpdateConfiguration(&ev);
+    LOG_TRACE(("RandR change received; reconfiguring monitors\n"));
+
+    if (is_screen_change)
+        XRRUpdateConfiguration(&ev);
     xinerama_query_monitors(tray_data.dpy);
 
     if (!tray_data.xinerama_active)

--- a/src/xinerama.c
+++ b/src/xinerama.c
@@ -3,29 +3,63 @@
 #include "debug.h"
 #include "xinerama.h"
 
+#if defined(_ST_WITH_XINERAMA) || defined(_ST_WITH_XRANDR)
+#include "tray.h"
+#endif
+
 #ifdef _ST_WITH_XINERAMA
 #include <X11/extensions/Xinerama.h>
 
-#include "tray.h"
 #include "settings.h"
 #endif
 
-void xinerama_init(Display *dpy)
-{
+#ifdef _ST_WITH_XRANDR
+#include <X11/extensions/Xrandr.h>
+#endif
+
 #ifdef _ST_WITH_XINERAMA
+static void xinerama_query_monitors(Display *dpy)
+{
+    if (tray_data.monitors != NULL) {
+        XFree(tray_data.monitors);
+        tray_data.monitors = NULL;
+    }
+    tray_data.n_monitors = 0;
+
     if (!XineramaIsActive(dpy)) {
-        LOG_TRACE(("Xinerama is not active, returning\n"));
+        tray_data.xinerama_active = False;
+        LOG_TRACE(("Xinerama is not active\n"));
         return;
     }
-
-    LOG_TRACE(("Xinerama is active\n"));
 
     tray_data.xinerama_active = True;
     tray_data.monitors = XineramaQueryScreens(dpy, &tray_data.n_monitors);
 
     LOG_TRACE(("Xinerama reports %d monitors\n", tray_data.n_monitors));
-#else
+}
+#endif
+
+void xinerama_init(Display *dpy)
+{
+#if !defined(_ST_WITH_XINERAMA) && !defined(_ST_WITH_XRANDR)
     (void) dpy; /* unused */
+#endif
+#ifdef _ST_WITH_XINERAMA
+    xinerama_query_monitors(dpy);
+#endif
+#ifdef _ST_WITH_XRANDR
+    {
+        int error_base;
+        if (XRRQueryExtension(dpy, &tray_data.randr_event_base, &error_base)) {
+            XRRSelectInput(
+                dpy, DefaultRootWindow(dpy), RRScreenChangeNotifyMask);
+            LOG_TRACE(("RandR active, event base %d\n",
+                tray_data.randr_event_base));
+        } else {
+            tray_data.randr_event_base = -1;
+            LOG_TRACE(("RandR is not available\n"));
+        }
+    }
 #endif
 }
 
@@ -34,7 +68,7 @@ void xinerama_update_geometry(void)
 #ifdef _ST_WITH_XINERAMA
     XineramaScreenInfo chosen_monitor;
     unsigned int dummy;
-    int x = 0, y = 0, flags;
+    int x = 0, y = 0, flags, monitor;
 
     if (!tray_data.xinerama_active)
         return;
@@ -42,9 +76,18 @@ void xinerama_update_geometry(void)
     LOG_TRACE(("Updating geometry based on chosen Xinerama monitor\n"));
 
     flags = XParseGeometry(settings.geometry_str, &x, &y, &dummy, &dummy);
-    chosen_monitor = tray_data.monitors[settings.monitor];
 
-    LOG_TRACE(("Chosen monitor %d: %dx%d+%d+%d\n", settings.monitor,
+    /* The configured monitor may no longer exist (e.g. it was unplugged).
+     * Clamp to the available range without mutating settings.monitor, so the
+     * tray returns to the requested monitor once it comes back. */
+    monitor = settings.monitor;
+    if (monitor >= tray_data.n_monitors)
+        monitor = tray_data.n_monitors - 1;
+    if (monitor < 0)
+        monitor = 0;
+    chosen_monitor = tray_data.monitors[monitor];
+
+    LOG_TRACE(("Chosen monitor %d: %dx%d+%d+%d\n", monitor,
         chosen_monitor.width, chosen_monitor.height, chosen_monitor.x_org,
         chosen_monitor.y_org));
 
@@ -59,5 +102,43 @@ void xinerama_update_geometry(void)
     LOG_TRACE(("New tray position (x,y): %d,%d\n", tray_data.xsh.x, tray_data.xsh.y));
 #else
     return;
+#endif
+}
+
+void xinerama_handle_event(XEvent ev)
+{
+#if defined(_ST_WITH_XINERAMA) && defined(_ST_WITH_XRANDR)
+    XWindowAttributes root_wa;
+
+    if (tray_data.randr_event_base < 0
+        || ev.type != tray_data.randr_event_base + RRScreenChangeNotify)
+        return;
+
+    LOG_TRACE(("RRScreenChangeNotify received; reconfiguring monitors\n"));
+
+    XRRUpdateConfiguration(&ev);
+    xinerama_query_monitors(tray_data.dpy);
+
+    if (!tray_data.xinerama_active)
+        return;
+
+    /* Refresh the cached root window size; the screen bounding box changes
+     * when monitors are added or removed, and the strut autodetection relies
+     * on it. */
+    if (XGetWindowAttributes(
+            tray_data.dpy, DefaultRootWindow(tray_data.dpy), &root_wa)) {
+        tray_data.root_wnd.width = root_wa.width;
+        tray_data.root_wnd.height = root_wa.height;
+    }
+
+    /* Recompute the position as on startup and move the tray. The resulting
+     * ConfigureNotify on the tray window drives icon repositioning through the
+     * normal path; update the strut here too in case the move is a no-op. */
+    xinerama_update_geometry();
+    XMoveWindow(
+        tray_data.dpy, tray_data.tray, tray_data.xsh.x, tray_data.xsh.y);
+    tray_update_window_strut();
+#else
+    (void) ev; /* unused */
 #endif
 }

--- a/src/xinerama.h
+++ b/src/xinerama.h
@@ -5,5 +5,9 @@
 
 void xinerama_init(Display *dpy);
 void xinerama_update_geometry(void);
+/* React to a RandR screen change event by re-querying monitors and
+ * repositioning the tray as if it had just started up. No-op for events that
+ * are not RandR screen changes. */
+void xinerama_handle_event(XEvent ev);
 
 #endif


### PR DESCRIPTION
stalonetray now reacts to monitors being added/removed or repositioned through
XRandR.

This comes at the cost of a new dependency, so this feature is toggleable and
enabled by default.

Additionally, another shift-by-one-icon-spot bug was fixed.

- **feat: use xrandr to react to changes in monitors**
- **ci: install libxrandr-dev to build against xrandr**
- **build: refuse to compile with randr and no xinerama**
- **feat: detect when monitors are repositioned**
- **fix: call tray_update_window_props only once when redocking**

Fixes #37.
