### PR TITLE
feat: allow reloading configuration live

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,3 +128,37 @@ jobs:
               -D native_kde=enabled
             meson compile -C build stalonetray
             meson compile -C build manpage
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    needs: ubuntu
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v5
+
+      - name: Disable man-db auto-update
+        run: |
+          echo "set man-db/auto-update false" | sudo debconf-communicate
+          sudo dpkg-reconfigure man-db
+          sudo rm -f /var/lib/man-db/auto-update
+
+      - name: Install and cache dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >
+            xsltproc docbook-xsl libxpm-dev libx11-dev libxinerama-dev
+            libxrandr-dev libcmocka-dev meson
+
+      - name: Set up build directory
+        run: |
+          meson setup --buildtype release build -D c_std=gnu2x \
+            -D xinerama=enabled -D randr=enabled -D xpm=enabled \
+            -D native_kde=enabled -D tests=enabled
+
+      - name: Build
+        run: meson compile -C build
+
+      - name: Run tests
+        run: meson test -C build --print-errorlogs

--- a/meson.build
+++ b/meson.build
@@ -99,6 +99,14 @@ executable(
   install: true,
 )
 
+# == Tests =====================================================================
+
+cmocka_dep = dependency('cmocka', required: get_option('tests'))
+
+if cmocka_dep.found()
+  subdir('tests')
+endif
+
 # == Documentation =============================================================
 
 gen_manpage = find_program('generate-manpage.sh')

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'stalonetray',
   'c',
-  version: '1.3.0',
+  version: '1.4.0',
   default_options: ['warning_level=3', 'c_std=gnu23'],
   meson_version: '>=1.1.0',
 )

--- a/meson.options
+++ b/meson.options
@@ -15,3 +15,5 @@ option('dump_window_information', type: 'boolean', value: false,
   description: 'Use xprop/xwininfo to dump icon window information')
 option('exit_gracefully', type: 'boolean', value: true,
   description: 'Use non-portable hack to exit gracefully on signal')
+option('tests', type: 'feature', value: 'auto',
+  description: 'Build unit tests (requires libcmocka)')

--- a/src/image.c
+++ b/src/image.c
@@ -301,5 +301,7 @@ int image_compose_15(CARD16 *data, CARD16 *bg, CARD8 *mask, size_t len)
         *p = ((r >> 8) & 0x7c00) | ((g >> 8) & 0x3e0) | ((b >> 8) & 0x1f);
     }
 
+    (void) *m; /* unused */
+
     return SUCCESS;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -40,8 +40,8 @@
 #include "tray.h"
 #include "xinerama.h"
 
-static int tray_status_requested = 0;
-static int settings_reload_requested = 0;
+static volatile sig_atomic_t tray_status_requested = 0;
+static volatile sig_atomic_t settings_reload_requested = 0;
 /* Stashed at main() so SIGHUP reloads can re-apply the original cmdline. */
 static int reload_argc = 0;
 static char **reload_argv = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -235,7 +235,7 @@ void remove_icon(Window w)
     struct TrayIcon *ti;
     /* Ignore false alarms */
     if ((ti = icon_list_find(w)) == NULL) return;
-    dump_tray_status();
+    if (settings.log_level >= LOG_LEVEL_TRACE) dump_tray_status();
     drag_forget_icon(ti);
     embedder_unembed(ti);
     xembed_unembed(ti);
@@ -250,7 +250,7 @@ void remove_icon(Window w)
     scrollbars_click(SB_WND_MAX);
     tray_update_window_props();
     order_save();
-    dump_tray_status();
+    if (settings.log_level >= LOG_LEVEL_TRACE) dump_tray_status();
 }
 
 /* Track icon visibility state changes */

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,8 @@
 #include <X11/Xmd.h>
 #include <X11/Xutil.h>
 
+#include <errno.h>
+#include <fcntl.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
@@ -45,6 +47,11 @@ static volatile sig_atomic_t settings_reload_requested = 0;
 /* Stashed at main() so SIGHUP reloads can re-apply the original cmdline. */
 static int reload_argc = 0;
 static char **reload_argv = NULL;
+/* Self-pipe whose read end is select()ed alongside the X connection. SIGHUP
+ * writes a byte to wr to break the main loop out of an idle wait so the
+ * reload runs without having to wait for the next X event. */
+static int signal_pipe_rd = -1;
+static int signal_pipe_wr = -1;
 #ifdef _ST_EXIT_GRACEFULLY
 static Display *async_dpy;
 #endif
@@ -69,9 +76,10 @@ void request_tray_status_on_signal(int)
 
 void request_settings_reload_on_signal(int)
 {
-    /* Do the actual work in the event loop; only async-signal-safe writes are
-     * allowed here. */
     settings_reload_requested = 1;
+    char b = 0;
+    ssize_t r = write(signal_pipe_wr, &b, 1);
+    (void) r;
 }
 
 #ifdef _ST_EXIT_GRACEFULLY
@@ -996,19 +1004,9 @@ int tray_main(int argc, char **argv)
     kde_icons_update();
 #endif
     find_unmanaged_chromium_icons();
-    /* Main event loop */
+    int x_fd = ConnectionNumber(tray_data.dpy);
     while ("my guitar gently wheeps") {
-        /* This is ugly and extra dependency. But who cares?
-         * Rationale: we want to block unless absolutely needed.
-         * This way we ensure that stalonetray does not show up
-         * in powertop (i.e. does not eat unnecessary power and
-         * CPU cycles)
-         * Drawback: handling of signals is very limited. XNextEvent()
-         * does not if signal occurs. This means that graceful
-         * exit on e.g. Ctrl-C cannot be implemented without hacks. */
-        while (XPending(tray_data.dpy)
-            || (tray_data.scrollbars_data.scrollbar_down == -1
-                && !order_startup_pending())) {
+        while (XPending(tray_data.dpy)) {
             XNextEvent(tray_data.dpy, &ev);
             xembed_handle_event(ev);
             scrollbars_handle_event(ev);
@@ -1076,7 +1074,21 @@ int tray_main(int argc, char **argv)
             perform_periodic_tasks(PT_MASK_ALL & (~PT_MASK_SB));
         }
         perform_periodic_tasks(PT_MASK_ALL);
-        my_usleep(500000L);
+        if (tray_data.terminated) goto bailout;
+
+        int active = (tray_data.scrollbars_data.scrollbar_down != -1
+            || order_startup_pending());
+        struct timeval tv = {0, 500000};
+        fd_set rset;
+        FD_ZERO(&rset);
+        FD_SET(x_fd, &rset);
+        FD_SET(signal_pipe_rd, &rset);
+        int maxfd = (x_fd > signal_pipe_rd ? x_fd : signal_pipe_rd) + 1;
+        int n = select(maxfd, &rset, NULL, NULL, active ? &tv : NULL);
+        if (n > 0 && FD_ISSET(signal_pipe_rd, &rset)) {
+            char drain[16];
+            while (read(signal_pipe_rd, drain, sizeof(drain)) > 0) { }
+        }
     }
 bailout:
     LOG_TRACE(("Clean exit\n"));
@@ -1166,6 +1178,17 @@ int main(int argc, char **argv)
     reload_argv = argv;
     /* Register cleanup and signal handlers */
     atexit(cleanup);
+    {
+        int fds[2];
+        if (pipe(fds) < 0)
+            DIE(("could not create signal pipe: %s\n", strerror(errno)));
+        fcntl(fds[0], F_SETFL, O_NONBLOCK);
+        fcntl(fds[1], F_SETFL, O_NONBLOCK);
+        fcntl(fds[0], F_SETFD, FD_CLOEXEC);
+        fcntl(fds[1], F_SETFD, FD_CLOEXEC);
+        signal_pipe_rd = fds[0];
+        signal_pipe_wr = fds[1];
+    }
     signal(SIGUSR1, &request_tray_status_on_signal);
     signal(SIGHUP, &request_settings_reload_on_signal);
 #ifdef _ST_EXIT_GRACEFULLY

--- a/src/main.c
+++ b/src/main.c
@@ -40,8 +40,11 @@
 #include "tray.h"
 #include "xinerama.h"
 
-struct TrayData tray_data;
 static int tray_status_requested = 0;
+static int settings_reload_requested = 0;
+/* Stashed at main() so SIGHUP reloads can re-apply the original cmdline. */
+static int reload_argc = 0;
+static char **reload_argv = NULL;
 #ifdef _ST_EXIT_GRACEFULLY
 static Display *async_dpy;
 #endif
@@ -62,6 +65,13 @@ void my_usleep(useconds_t usec)
 void request_tray_status_on_signal(int)
 {
     tray_status_requested = 1;
+}
+
+void request_settings_reload_on_signal(int)
+{
+    /* Do the actual work in the event loop; only async-signal-safe writes are
+     * allowed here. */
+    settings_reload_requested = 1;
 }
 
 #ifdef _ST_EXIT_GRACEFULLY
@@ -366,6 +376,8 @@ void find_unmanaged_chromium_icons()
 #define PT_MASK_SB (1L << 0)
 #define PT_MASK_ALL PT_MASK_SB
 
+static void handle_settings_reload(void);
+
 /* Perform several periodic tasks */
 void perform_periodic_tasks(int mask)
 {
@@ -396,6 +408,8 @@ void perform_periodic_tasks(int mask)
     if (mask & PT_MASK_SB) scrollbars_periodic_tasks();
     /* 5. close the icon-order restore window once its timeout elapses */
     order_periodic();
+    /* 6. process a SIGHUP-triggered config reload, if one was requested */
+    handle_settings_reload();
 }
 
 /**********************
@@ -783,6 +797,179 @@ void unmap_notify(XUnmapEvent ev)
     }
 }
 
+/* NULL-safe string comparison: treats two NULLs as equal, NULL vs non-NULL as
+ * unequal. Used by the settings_reload apply step where wnd_layer/wnd_type/
+ * etc. can legitimately be NULL. */
+static int str_diff(const char *a, const char *b)
+{
+    if (a == NULL && b == NULL) return 0;
+    if (a == NULL || b == NULL) return 1;
+    return strcmp(a, b);
+}
+
+/* Remove every icon whose WM_CLASS now matches an entry in
+ * settings.ignored_classes. Newly-docking icons are handled by the existing
+ * is_ignored_class check in add_icon; this catches the icons that were
+ * already in the tray when the user added their class to the ignore list. */
+static void apply_reload_ignored_classes(void)
+{
+    struct TrayIcon *ti, *next;
+    char *classname;
+    for (ti = icons_head; ti != NULL; ti = next) {
+        next = ti->next;
+        classname = x11_get_window_class(tray_data.dpy, ti->wid);
+        if (classname == NULL) continue;
+        if (is_ignored_class(classname)) {
+            LOG_INFO(("removing icon 0x%lx: its class \"%s\" is now ignored\n",
+                ti->wid, classname));
+            remove_icon(ti->wid);
+        }
+        free(classname);
+    }
+}
+
+/* Has anything that feeds into tray_update_bg() changed? */
+static int bg_settings_changed(const struct Settings *old)
+{
+    return old->parent_bg != settings.parent_bg
+        || old->transparent != settings.transparent
+        || old->pixmap_bg != settings.pixmap_bg
+        || old->fuzzy_edges != settings.fuzzy_edges
+        || old->tint_level != settings.tint_level
+        || str_diff(old->bg_color_str, settings.bg_color_str) != 0
+        || str_diff(old->tint_color_str, settings.tint_color_str) != 0
+        || str_diff(old->bg_pmap_path, settings.bg_pmap_path) != 0;
+}
+
+/* Replace the tray's WM_NAME with the (possibly new) settings.wnd_name. */
+static void apply_reload_wnd_name(void)
+{
+    XTextProperty wm_name;
+    if (XmbTextListToTextProperty(tray_data.dpy, &settings.wnd_name, 1,
+            XTextStyle, &wm_name)
+        != Success) {
+        LOG_ERROR(("reload: invalid window name \"%s\"\n", settings.wnd_name));
+        return;
+    }
+    XSetWMName(tray_data.dpy, tray_data.tray, &wm_name);
+    XFree(wm_name.value);
+}
+
+/* Replace _NET_WM_WINDOW_TYPE wholesale. tray_set_wm_hints uses
+ * PropModeAppend, so calling it repeatedly on reload would accumulate atoms;
+ * clear the property first and re-add the (user_type, NORMAL) pair fresh. */
+static void apply_reload_wnd_type(void)
+{
+    Atom prop = XInternAtom(tray_data.dpy, "_NET_WM_WINDOW_TYPE", False);
+    XDeleteProperty(tray_data.dpy, tray_data.tray, prop);
+    if (strcmp(settings.wnd_type, _NET_WM_WINDOW_TYPE_NORMAL) != 0)
+        ewmh_add_window_type(
+            tray_data.dpy, tray_data.tray, settings.wnd_type);
+    ewmh_add_window_type(
+        tray_data.dpy, tray_data.tray, _NET_WM_WINDOW_TYPE_NORMAL);
+}
+
+/* Re-apply MWM decoration hints. mwm_set_hints uses PropModeReplace so this
+ * is just a straight re-call (unlike the EWMH state functions). */
+static void apply_reload_deco_flags(void)
+{
+    int mwm_decor = 0;
+    if (settings.deco_flags & DECO_TITLE)
+        mwm_decor |= MWM_DECOR_TITLE | MWM_DECOR_MENU;
+    if (settings.deco_flags & DECO_BORDER)
+        mwm_decor |= MWM_DECOR_RESIZEH | MWM_DECOR_BORDER;
+    mwm_set_hints(
+        tray_data.dpy, tray_data.tray, mwm_decor, MWM_FUNC_ALL);
+}
+
+/* Apply each piece of the reload that needs an actual side-effect, gated on
+ * "did this actually change since before the reload". */
+static void apply_settings_reload(const struct Settings *old)
+{
+#ifdef _ST_WITH_XINERAMA
+    if (old->monitor != settings.monitor && tray_data.xinerama_active) {
+        xinerama_update_geometry();
+        XMoveWindow(tray_data.dpy, tray_data.tray, tray_data.xsh.x,
+            tray_data.xsh.y);
+        tray_update_window_strut();
+    }
+#endif
+
+    /* Walk every reload, even when the list looks unchanged: a config edit
+     * is the only reason we got here and the cost is one X round-trip per
+     * icon. */
+    apply_reload_ignored_classes();
+
+    if (bg_settings_changed(old)) {
+        tray_update_bg(True);
+        tray_refresh_window(True);
+    }
+
+    if (old->wm_strut_mode != settings.wm_strut_mode)
+        tray_update_window_strut();
+
+    if (str_diff(old->wnd_name, settings.wnd_name) != 0)
+        apply_reload_wnd_name();
+
+    if (old->sticky != settings.sticky) {
+        if (settings.sticky)
+            ewmh_add_window_state(
+                tray_data.dpy, tray_data.tray, _NET_WM_STATE_STICKY);
+        else
+            ewmh_remove_window_state(
+                tray_data.dpy, tray_data.tray, _NET_WM_STATE_STICKY);
+    }
+
+    if (old->skip_taskbar != settings.skip_taskbar) {
+        if (settings.skip_taskbar)
+            ewmh_add_window_state(tray_data.dpy, tray_data.tray,
+                _NET_WM_STATE_SKIP_TASKBAR);
+        else
+            ewmh_remove_window_state(tray_data.dpy, tray_data.tray,
+                _NET_WM_STATE_SKIP_TASKBAR);
+    }
+
+    if (str_diff(old->wnd_layer, settings.wnd_layer) != 0) {
+        if (old->wnd_layer != NULL)
+            ewmh_remove_window_state(
+                tray_data.dpy, tray_data.tray, old->wnd_layer);
+        if (settings.wnd_layer != NULL)
+            ewmh_add_window_state(
+                tray_data.dpy, tray_data.tray, settings.wnd_layer);
+    }
+
+    if (str_diff(old->wnd_type, settings.wnd_type) != 0)
+        apply_reload_wnd_type();
+
+    if (old->deco_flags != settings.deco_flags)
+        apply_reload_deco_flags();
+
+    if (str_diff(old->scrollbars_highlight_color_str,
+            settings.scrollbars_highlight_color_str)
+        != 0)
+        scrollbars_update();
+}
+
+static void handle_settings_reload(void)
+{
+    struct Settings old;
+    if (!settings_reload_requested) return;
+    settings_reload_requested = 0;
+    LOG_INFO(("reloading configuration\n"));
+    if (settings_reload(reload_argc, reload_argv, &old) != SUCCESS) {
+        LOG_ERROR(("reload aborted; keeping current settings\n"));
+        /* On failure settings_reload zeroed *out_old, so this is a no-op. */
+        free_settings(&old);
+        return;
+    }
+    apply_settings_reload(&old);
+    /* Releases the pre-reload heap content that settings_reload handed back
+     * via out_old: reloadable strings + the old ignored_classes list. The
+     * non-reloadable string slots in `old` were cleared by settings_reload
+     * since they still alias the live `settings`. */
+    free_settings(&old);
+}
+
 /*********************************************************/
 /* main() for usual operation */
 int tray_main(int argc, char **argv)
@@ -973,9 +1160,14 @@ int main(int argc, char **argv)
     /* Read settings */
     tray_init();
     read_settings(argc, argv);
+    /* Stash for SIGHUP-triggered reloads: argv is valid for the lifetime of
+     * the process. */
+    reload_argc = argc;
+    reload_argv = argv;
     /* Register cleanup and signal handlers */
     atexit(cleanup);
     signal(SIGUSR1, &request_tray_status_on_signal);
+    signal(SIGHUP, &request_settings_reload_on_signal);
 #ifdef _ST_EXIT_GRACEFULLY
     signal(SIGINT, &exit_on_signal);
     signal(SIGTERM, &exit_on_signal);

--- a/src/main.c
+++ b/src/main.c
@@ -1182,7 +1182,7 @@ int main(int argc, char **argv)
     if ((async_dpy = XOpenDisplay(settings.display_str)) == NULL)
         DIE(("could not open display\n"));
     else
-        LOG_TRACE(("Opened async dpy %p\n", async_dpy));
+        LOG_TRACE(("Opened async dpy %p\n", (void *) async_dpy));
 #endif
     if (settings.xsync) XSynchronize(tray_data.dpy, True);
     x11_trap_errors();

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,21 +1,26 @@
-project_sources += [
-  'src/debug.c',
-  'src/drag.c',
-  'src/embed.c',
-  'src/icons.c',
-  'src/image.c',
-  'src/layout.c',
-  'src/main.c',
-  'src/order.c',
-  'src/scrollbars.c',
-  'src/settings.c',
-  'src/tray.c',
-  'src/wmh.c',
-  'src/xembed.c',
-  'src/xinerama.c',
-  'src/xutils.c',
-]
+# Everything but main.c: linked into both the stalonetray binary and the
+# unit-test binaries so we don't get two definitions of main(). Use files()
+# so the resulting File objects resolve regardless of the meson.build that
+# consumes them (tests/meson.build pulls these in too).
+core_sources = files(
+  'debug.c',
+  'drag.c',
+  'embed.c',
+  'icons.c',
+  'image.c',
+  'layout.c',
+  'order.c',
+  'scrollbars.c',
+  'settings.c',
+  'tray.c',
+  'wmh.c',
+  'xembed.c',
+  'xinerama.c',
+  'xutils.c',
+)
 
 if get_option('native_kde').enabled()
-  project_sources += ['src/kde_tray.c']
+  core_sources += files('kde_tray.c')
 endif
+
+project_sources += core_sources + [files('main.c')]

--- a/src/order.c
+++ b/src/order.c
@@ -347,11 +347,17 @@ void order_place_icon(struct TrayIcon *ti)
     order.entries[idx].claimed = 1;
     order.entries[idx].claimed_wid = ti->wid;
     order.n_reclaimed++;
-    /* Splice ti ahead of the first icon that outranks it (gravity-placed icons
-     * rank INT_MAX, so restored icons cluster ahead of them in rank order). */
+    /* Splice ti ahead of the first ranked icon that outranks it. Ignored or
+     * gravity-placed icons (rank INT_MAX) are skipped so ti doesn't end up
+     * stuck in front of a phantom that arrived before any of the snapshot
+     * icons -- their rank is INT_MAX, INT_MAX > idx is trivially true, and
+     * the splice would otherwise drag ti to the very head of the list. */
     for (p = icons_head; p != NULL; p = p->next) {
+        int prank;
         if (p == ti) continue;
-        if (order_rank_of(p->wid) > idx) {
+        prank = order_rank_of(p->wid);
+        if (prank == INT_MAX) continue;
+        if (prank > idx) {
             before = p;
             break;
         }

--- a/src/settings.c
+++ b/src/settings.c
@@ -15,6 +15,8 @@
 #include <errno.h>
 #include <libgen.h>
 #include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -34,68 +36,98 @@
 
 /* Here we keep our filthy settings */
 struct Settings settings;
-/* Initialize data */
+
+/* Parsers write fields into *parse_target; each Param's struct_offset is the
+ * offsetof() into struct Settings for the field that param drives. This lets
+ * settings_reload parse into a scratch struct without touching the live
+ * `settings` until the merge step. */
+static struct Settings *parse_target = &settings;
+
+/* Resolve a parser's struct_offset into a typed lvalue inside parse_target. */
+#define REF(type) ((type *) ((char *) parse_target + struct_offset))
+
+/* strdup() that DIEs on OOM and passes NULL through unchanged. Used for every
+ * string assigned into a settings field, so heap ownership is uniform across
+ * the struct: every char* in struct Settings is either NULL or a heap pointer
+ * owned by that struct (free_settings can release them blindly). */
+static char *xstrdup(const char *s)
+{
+    char *r;
+    if (s == NULL) return NULL;
+    if ((r = strdup(s)) == NULL) DIE_OOM(("strdup() failed for \"%s\"\n", s));
+    return r;
+}
+
+/* Replace a heap-owned string field with a strdup of `s`. Frees the old value
+ * first; safe to call when *slot is NULL (e.g. immediately after memset). */
+static void set_str(char **slot, const char *s)
+{
+    free(*slot);
+    *slot = xstrdup(s);
+}
+
+/* Forward declaration; the body lives further down with the other parsers. */
+void free_window_class_list(struct WindowClass *head);
+
+void free_settings(struct Settings *s)
+{
+    free(s->bg_color_str);
+    free(s->tint_color_str);
+    free(s->scrollbars_highlight_color_str);
+    free(s->display_str);
+    free(s->geometry_str);
+    free(s->max_geometry_str);
+    free(s->wnd_type);
+    free(s->wnd_layer);
+    free(s->wnd_name);
+    free(s->bg_pmap_path);
+    free(s->config_fname);
+    free(s->icon_order_file);
+    free(s->remote_click_name);
+    free_window_class_list(s->ignored_classes);
+    memset(s, 0, sizeof(*s));
+}
+
+/* (Re-)populate *parse_target with default values. Safe to call repeatedly:
+ * any existing heap content is freed first via free_settings(). */
 void init_default_settings(void)
 {
-    settings.bg_color_str = "gray";
-    settings.tint_color_str = "white";
-    settings.scrollbars_highlight_color_str = "white";
-    settings.display_str = NULL;
-#ifdef DEBUG
-    settings.log_level = LOG_LEVEL_ERR;
-#endif
-    settings.geometry_str = NULL;
-    settings.max_geometry_str = "0x0";
-    settings.icon_size = FALLBACK_ICON_SIZE;
-    settings.slot_size.x = -1;
-    settings.slot_size.y = -1;
-    settings.deco_flags = DECO_NONE;
-    settings.max_tray_dims.x = 0;
-    settings.max_tray_dims.y = 0;
-    settings.parent_bg = 0;
-    settings.shrink_back_mode = 1;
-    settings.sticky = 1;
-    settings.skip_taskbar = 1;
-    settings.transparent = 0;
-    settings.vertical = 0;
-    settings.grow_gravity = GRAV_N | GRAV_W;
-    settings.icon_gravity = GRAV_N | GRAV_W;
-    settings.wnd_type = _NET_WM_WINDOW_TYPE_DOCK;
-    settings.wnd_layer = NULL;
-    settings.wnd_name = PROGNAME;
-    settings.xsync = 0;
-    settings.need_help = 0;
-    settings.config_fname = NULL;
-    settings.full_pmt_search = 1;
-    settings.min_space_policy = 0;
-    settings.pixmap_bg = 0;
-    settings.bg_pmap_path = NULL;
-    settings.tint_level = 0;
-    settings.fuzzy_edges = 0;
-    settings.dockapp_mode = DOCKAPP_NONE;
-    settings.scrollbars_size = -1;
-    settings.scrollbars_mode = SB_MODE_NONE;
-    settings.scrollbars_inc = -1;
-    settings.wm_strut_mode = WM_STRUT_AUTO;
-    settings.kludge_flags = 0;
-    settings.remote_click_name = NULL;
-    settings.remote_click_btn = REMOTE_CLICK_BTN_DEFAULT;
-    settings.remote_click_cnt = REMOTE_CLICK_CNT_DEFAULT;
-    settings.remote_click_pos.x = REMOTE_CLICK_POS_DEFAULT;
-    settings.remote_click_pos.y = REMOTE_CLICK_POS_DEFAULT;
-    settings.ignored_classes = NULL;
-    settings.scroll_everywhere = 0;
-    settings.drag_reorder = 1;
-    settings.drag_modifier = Mod1Mask;
-    settings.remember_icon_order = 1;
-    settings.icon_order_file = NULL;
-    settings.icon_order_timeout = 10;
-#ifdef DELAY_EMBEDDING_CONFIRMATION
-    settings.confirmation_delay = 3;
-#endif
+    free_settings(parse_target);
 
-#ifdef _ST_WITH_XINERAMA
-    settings.monitor = 0;
+    set_str(&parse_target->bg_color_str, "gray");
+    set_str(&parse_target->tint_color_str, "white");
+    set_str(&parse_target->scrollbars_highlight_color_str, "white");
+    set_str(&parse_target->max_geometry_str, "0x0");
+    set_str(&parse_target->wnd_type, _NET_WM_WINDOW_TYPE_DOCK);
+    set_str(&parse_target->wnd_name, PROGNAME);
+
+#ifdef DEBUG
+    parse_target->log_level = LOG_LEVEL_ERR;
+#endif
+    parse_target->icon_size = FALLBACK_ICON_SIZE;
+    parse_target->slot_size.x = -1;
+    parse_target->slot_size.y = -1;
+    parse_target->deco_flags = DECO_NONE;
+    parse_target->shrink_back_mode = 1;
+    parse_target->sticky = 1;
+    parse_target->skip_taskbar = 1;
+    parse_target->grow_gravity = GRAV_N | GRAV_W;
+    parse_target->icon_gravity = GRAV_N | GRAV_W;
+    parse_target->full_pmt_search = 1;
+    parse_target->scrollbars_size = -1;
+    parse_target->scrollbars_mode = SB_MODE_NONE;
+    parse_target->scrollbars_inc = -1;
+    parse_target->wm_strut_mode = WM_STRUT_AUTO;
+    parse_target->remote_click_btn = REMOTE_CLICK_BTN_DEFAULT;
+    parse_target->remote_click_cnt = REMOTE_CLICK_CNT_DEFAULT;
+    parse_target->remote_click_pos.x = REMOTE_CLICK_POS_DEFAULT;
+    parse_target->remote_click_pos.y = REMOTE_CLICK_POS_DEFAULT;
+    parse_target->drag_reorder = 1;
+    parse_target->drag_modifier = Mod1Mask;
+    parse_target->remember_icon_order = 1;
+    parse_target->icon_order_timeout = 10;
+#ifdef DELAY_EMBEDDING_CONFIRMATION
+    parse_target->confirmation_delay = 3;
 #endif
 }
 
@@ -105,22 +137,21 @@ void init_default_settings(void)
     if (!silent) LOG_ERROR(("Parsing error: " msg ", \"%s\" found\n", str));
 
 /* Parse highlight color */
-int parse_scrollbars_highlight_color(int, const char **argv, void **references, int)
+int parse_scrollbars_highlight_color(int, const char **argv, size_t struct_offset, int)
 {
-    char **highlight_color = (char **) references[0];
+    char **highlight_color = REF(char *);
 
-    if (!strcasecmp(argv[0], "disable"))
-        *highlight_color = NULL;
-    else if ((*highlight_color = strdup(argv[0])) == NULL)
-        DIE_OOM(("Could not copy value from parameter\n"));
-
+    free(*highlight_color);
+    *highlight_color = strcasecmp(argv[0], "disable") == 0
+                         ? NULL
+                         : xstrdup(argv[0]);
     return SUCCESS;
 }
 
 /* Parse log level */
-int parse_log_level(int, const char **argv, void **references, int silent)
+int parse_log_level(int, const char **argv, size_t struct_offset, int silent)
 {
-    int *log_level = (int *) references[0];
+    int *log_level = REF(int);
 
     if (!strcmp(argv[0], "err"))
         *log_level = LOG_LEVEL_ERR;
@@ -136,15 +167,16 @@ int parse_log_level(int, const char **argv, void **references, int silent)
 }
 
 /* Parse list of ignored window classes */
-int parse_ignored_classes(int argc, const char **argv, void **references, int)
+int parse_ignored_classes(int argc, const char **argv, size_t struct_offset, int)
 {
-    struct WindowClass **classes = (struct WindowClass **) references[0];
-    struct WindowClass *newclass = NULL;
+    struct WindowClass **classes = REF(struct WindowClass *);
+    struct WindowClass *newclass;
     int i;
 
     for (i = 0; i < argc; i++) {
-        newclass = malloc(sizeof(struct WindowClass));
-        newclass->name = strdup(argv[i]);
+        newclass = malloc(sizeof(*newclass));
+        if (newclass == NULL) DIE_OOM(("could not allocate WindowClass\n"));
+        newclass->name = xstrdup(argv[i]);
         LIST_ADD_ITEM(*classes, newclass);
     }
 
@@ -152,9 +184,9 @@ int parse_ignored_classes(int argc, const char **argv, void **references, int)
 }
 
 /* Parse dockapp mode */
-int parse_dockapp_mode(int, const char **argv, void **references, int silent)
+int parse_dockapp_mode(int, const char **argv, size_t struct_offset, int silent)
 {
-    int *dockapp_mode = (int *) references[0];
+    int *dockapp_mode = REF(int);
 
     if (!strcmp(argv[0], "none"))
         *dockapp_mode = DOCKAPP_NONE;
@@ -171,9 +203,9 @@ int parse_dockapp_mode(int, const char **argv, void **references, int silent)
 
 /* Parse gravity string ORing resulting value
  * with current value of tgt */
-int parse_gravity(int, const char **argv, void **references, int silent)
+int parse_gravity(int, const char **argv, size_t struct_offset, int silent)
 {
-    int *gravity = (int *) references[0];
+    int *gravity = REF(int);
     const char *gravity_s = argv[0];
     int parsed = 0;
 
@@ -204,9 +236,9 @@ fail:
 }
 
 /* Parse integer string storing resulting value in tgt */
-int parse_int(int, const char **argv, void **references, int silent)
+int parse_int(int, const char **argv, size_t struct_offset, int silent)
 {
-    int *parsed = (int *) references[0];
+    int *parsed = REF(int);
     char *invalid;
 
     *parsed = strtol(argv[0], &invalid, 0);
@@ -220,10 +252,10 @@ int parse_int(int, const char **argv, void **references, int silent)
 }
 
 /* Parse kludges mode */
-int parse_kludges(int, const char **argv, void **references, int silent)
+int parse_kludges(int, const char **argv, size_t struct_offset, int silent)
 {
     const char *token = strtok((char *) argv[0], ",");
-    int *kludges = (int *) references[0];
+    int *kludges = REF(int);
 
     for (; token != NULL; token = strtok(NULL, ",")) {
         if (!strcasecmp(token, "fix_window_pos"))
@@ -242,9 +274,9 @@ int parse_kludges(int, const char **argv, void **references, int silent)
 }
 
 /* Parse strut mode */
-int parse_strut_mode(int, const char **argv, void **references, int silent)
+int parse_strut_mode(int, const char **argv, size_t struct_offset, int silent)
 {
-    int *strut_mode = (int *) references[0];
+    int *strut_mode = REF(int);
 
     if (!strcasecmp(argv[0], "auto"))
         *strut_mode = WM_STRUT_AUTO;
@@ -268,9 +300,9 @@ int parse_strut_mode(int, const char **argv, void **references, int silent)
 }
 
 /* Parse X11 modifier name (alt, shift, ctrl, super, none) into a mask. */
-int parse_modifier(int, const char **argv, void **references, int silent)
+int parse_modifier(int, const char **argv, size_t struct_offset, int silent)
 {
-    unsigned int *mask = (unsigned int *) references[0];
+    unsigned int *mask = REF(unsigned int);
     const char *name = argv[0];
 
     if (!strcasecmp(name, "alt") || !strcasecmp(name, "mod1"))
@@ -291,11 +323,11 @@ int parse_modifier(int, const char **argv, void **references, int silent)
 }
 
 /* Parse boolean string storing result in tgt*/
-int parse_bool(int, const char **argv, void **references, int silent)
+int parse_bool(int, const char **argv, size_t struct_offset, int silent)
 {
     const char *true_str[] = {"yes", "on", "true", "1", NULL};
     const char *false_str[] = {"no", "off", "false", "0", NULL};
-    int *boolean = (int *) references[0];
+    int *boolean = REF(int);
 
     for (const char **s = true_str; *s; s++) {
         if (!strcasecmp(argv[0], *s)) {
@@ -316,11 +348,11 @@ int parse_bool(int, const char **argv, void **references, int silent)
 }
 
 /* Backwards version of the boolean parser */
-int parse_bool_rev(int argc, const char **argv, void **references, int silent)
+int parse_bool_rev(int argc, const char **argv, size_t struct_offset, int silent)
 {
-    int *boolean = (int *) references[0];
+    int *boolean = REF(int);
 
-    if (parse_bool(argc, argv, references, silent)) {
+    if (parse_bool(argc, argv, struct_offset, silent)) {
         *boolean = ! *boolean;
         return SUCCESS;
     }
@@ -329,63 +361,66 @@ int parse_bool_rev(int argc, const char **argv, void **references, int silent)
 }
 
 /* Parse window layer string storing result in tgt */
-int parse_wnd_layer(int, const char **argv, void **references, int silent)
+int parse_wnd_layer(int, const char **argv, size_t struct_offset, int silent)
 {
-    char **window_layer = (char **) references[0];
+    const char *layer;
+    char **window_layer = REF(char *);
 
     if (!strcasecmp(argv[0], "top"))
-        *window_layer = _NET_WM_STATE_ABOVE;
+        layer = _NET_WM_STATE_ABOVE;
     else if (!strcasecmp(argv[0], "bottom"))
-        *window_layer = _NET_WM_STATE_BELOW;
+        layer = _NET_WM_STATE_BELOW;
     else if (!strcasecmp(argv[0], "normal"))
-        *window_layer = NULL;
+        layer = NULL;
     else {
         PARSING_ERROR("window layer expected", argv[0]);
         return FAILURE;
     }
 
+    free(*window_layer);
+    *window_layer = xstrdup(layer);
     return SUCCESS;
 }
 
 /* Parse window type string storing result in tgt */
-int parse_wnd_type(int, const char **argv, void **references, int silent)
+int parse_wnd_type(int, const char **argv, size_t struct_offset, int silent)
 {
-    const char **window_type = (const char **) references[0];
+    const char *type;
+    char **window_type = REF(char *);
 
     if (!strcasecmp(argv[0], "dock"))
-        *window_type = _NET_WM_WINDOW_TYPE_DOCK;
+        type = _NET_WM_WINDOW_TYPE_DOCK;
     else if (!strcasecmp(argv[0], "toolbar"))
-        *window_type = _NET_WM_WINDOW_TYPE_TOOLBAR;
+        type = _NET_WM_WINDOW_TYPE_TOOLBAR;
     else if (!strcasecmp(argv[0], "utility"))
-        *window_type = _NET_WM_WINDOW_TYPE_UTILITY;
+        type = _NET_WM_WINDOW_TYPE_UTILITY;
     else if (!strcasecmp(argv[0], "normal"))
-        *window_type = _NET_WM_WINDOW_TYPE_NORMAL;
+        type = _NET_WM_WINDOW_TYPE_NORMAL;
     else if (!strcasecmp(argv[0], "desktop"))
-        *window_type = _NET_WM_WINDOW_TYPE_DESKTOP;
+        type = _NET_WM_WINDOW_TYPE_DESKTOP;
     else {
         PARSING_ERROR("window type expected", argv[0]);
         return FAILURE;
     }
 
+    free(*window_type);
+    *window_type = xstrdup(type);
     return SUCCESS;
 }
 
 /* Just copy string from arg to *tgt */
-int parse_copystr(int, const char **argv, void **references, int)
+int parse_copystr(int, const char **argv, size_t struct_offset, int)
 {
-    const char **stringref = (const char **) references[0];
-
-    /* Valgrind note: this memory will never be freed before stalonetray's exit. */
-    if ((*stringref = strdup(argv[0])) == NULL)
-        DIE_OOM(("Could not copy value from parameter\n"));
-
+    char **stringref = REF(char *);
+    free(*stringref);
+    *stringref = xstrdup(argv[0]);
     return SUCCESS;
 }
 
 /* Parses window decoration specification */
-int parse_deco(int, const char **argv, void **references, int silent)
+int parse_deco(int, const char **argv, size_t struct_offset, int silent)
 {
-    int *decorations = (int *) references[0];
+    int *decorations = REF(int);
     const char *arg = argv[0];
 
     if (!strcasecmp(arg, "none"))
@@ -404,9 +439,9 @@ int parse_deco(int, const char **argv, void **references, int silent)
 }
 
 /* Parses window decoration specification */
-int parse_sb_mode(int, const char **argv, void **references, int silent)
+int parse_sb_mode(int, const char **argv, size_t struct_offset, int silent)
 {
-    int *sb_mode = (int *) references[0];
+    int *sb_mode = REF(int);
 
     if (!strcasecmp(argv[0], "none"))
         *sb_mode = 0;
@@ -424,56 +459,9 @@ int parse_sb_mode(int, const char **argv, void **references, int silent)
     return SUCCESS;
 }
 
-#if 0
-/* Parses remote op specification */
-int parse_remote(char *str, void **tgt, int silent)
+int parse_remote_click_type(int, const char **argv, size_t struct_offset, int silent)
 {
-#define NEXT_TOK(str, rest) \
-    do { \
-        (str) = (rest); \
-        if ((str) != NULL) { \
-            (rest) = strchr((str), ','); \
-            if ((rest) != NULL) *((rest)++) = 0; \
-        } \
-    } while (0)
-#define PARSE_INT(tgt, str, tail, def, msg) \
-    do { \
-        if (str == NULL || *(str) == '\0') { \
-            (tgt) = def; \
-        } else { \
-            (tgt) = strtol((str), &(tail), 0); \
-            if (*(tail) != '\0') { \
-                PARSING_ERROR(msg, (str)); \
-                return FAILURE; \
-            } \
-        } \
-    } while (0)
-	/* Handy names for parameters */
-	int *flag = (int *) tgt[0];
-	char **name = (char **) tgt[1];
-	int *btn = (int *) tgt[2];
-	struct Point *pos = (struct Point *) tgt[3];
-	/* Local variables */
-	char *rest = str, *tail;
-	if (str == NULL || strlen(str) == 0) return FAILURE;
-	*flag = 1;
-	NEXT_TOK(str, rest);
-	*name = strdup(str);
-	NEXT_TOK(str, rest);
-	PARSE_INT(*btn, str, tail, INT_MIN, "remote click: button number expected");
-	NEXT_TOK(str, rest);
-	PARSE_INT(pos->x, str, tail, INT_MIN, "remote click: x coordinate expected");
-	NEXT_TOK(str, rest);
-	PARSE_INT(pos->y, str, tail, INT_MIN, "remote click: y coordinate expected");
-	return SUCCESS;
-#undef NEXT_TOK
-#undef PARSE_INT
-}
-#endif
-
-int parse_remote_click_type(int, const char **argv, void **references, int silent)
-{
-    int *remote_click_type = (int *) references[0];
+    int *remote_click_type = REF(int);
 
     if (!strcasecmp(argv[0], "single"))
         *remote_click_type = 1;
@@ -487,17 +475,17 @@ int parse_remote_click_type(int, const char **argv, void **references, int silen
     return SUCCESS;
 }
 
-int parse_pos(int, const char **argv, void **references, int)
+int parse_pos(int, const char **argv, size_t struct_offset, int)
 {
-    struct Point *pos = (struct Point *) references[0];
+    struct Point *pos = REF(struct Point);
     unsigned int dummy;
     XParseGeometry(argv[0], &pos->x, &pos->y, &dummy, &dummy);
     return SUCCESS;
 }
 
-int parse_size(int, const char **argv, void **references, int)
+int parse_size(int, const char **argv, size_t struct_offset, int)
 {
-    struct Point *size = (struct Point *) references[0];
+    struct Point *size = REF(struct Point);
     unsigned int width, height;
     int bitmask, dummy;
 
@@ -516,17 +504,20 @@ int parse_size(int, const char **argv, void **references, int)
 
 /************ CLI **************/
 
-#define MAX_TARGETS 10
 #define MAX_DEFAULT_ARGS 10
 
 /* parameter parser function */
-typedef int (*param_parser_t)(int argc, const char **argv, void **references, int silent);
+typedef int (*param_parser_t)(int argc, const char **argv, size_t struct_offset, int silent);
 
 struct Param {
-    const char *short_name;        /* short command line parameter name */
-    const char *long_name;         /* long command line parameter name */
-    const char *rc_name;           /* parameter name for config file */
-    void *references[MAX_TARGETS]; /* array of references necessary when parsing */
+    const char *short_name; /* short command line parameter name */
+    const char *long_name;  /* long command line parameter name */
+    const char *rc_name;    /* parameter name for config file */
+
+    /* Where the parser writes its result. Given as offsetof(struct Settings,
+     * field) in each table entry below, and resolved against parse_target at
+     * parse time via the REF() macro. */
+    size_t struct_offset;
 
     const int pass; /* 0th pass parameters are parsed before rc file, */
                     /* 1st pass parameters are parsed after it */
@@ -538,14 +529,19 @@ struct Param {
     const char *default_argv[MAX_DEFAULT_ARGS]; /* default arguments if none are given */
 
     param_parser_t parser;  /* pointer to parsing function */
+
+    /* Whether this parameter is safe to re-parse from the config file on
+     * SIGHUP-driven reloads. parse_rc() skips entries with reloadable == 0
+     * when it is being called for a reload, so that they aren't re-strdup'd
+     * just to be thrown away. */
+    const int reloadable;
 };
 
 struct Param params[] = {
-    {
-        .short_name = "-display",
-        .long_name  = NULL,
-        .rc_name    = "display",
-        .references = { (void *) &settings.display_str },
+    {.short_name = "-display",
+        .long_name = NULL,
+        .rc_name = "display",
+        .struct_offset = offsetof(struct Settings, display_str),
 
         .pass = 1,
 
@@ -555,13 +551,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_copystr
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_copystr},
+    {.short_name = NULL,
         .long_name = "--log-level",
         .rc_name = "log_level",
-        .references = { (void *) &settings.log_level },
+        .struct_offset = offsetof(struct Settings, log_level),
 
         .pass = 1,
 
@@ -571,13 +565,12 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_log_level
-    },
-    {
-        .short_name = "-bg",
+        .parser = (param_parser_t)&parse_log_level,
+        .reloadable = True},
+    {.short_name = "-bg",
         .long_name = "--background",
         .rc_name = "background",
-        .references = { (void *) &settings.bg_color_str },
+        .struct_offset = offsetof(struct Settings, bg_color_str),
 
         .pass = 1,
 
@@ -587,13 +580,12 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_copystr
-    },
-    {
-        .short_name = "-c",
+        .parser = (param_parser_t)&parse_copystr,
+        .reloadable = True},
+    {.short_name = "-c",
         .long_name = "--config",
         .rc_name = NULL,
-        .references = { (void *) &settings.config_fname },
+        .struct_offset = offsetof(struct Settings, config_fname),
 
         .pass = 0,
 
@@ -603,13 +595,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_copystr
-    },
-    {
-        .short_name = "-d",
+        .parser = (param_parser_t)&parse_copystr},
+    {.short_name = "-d",
         .long_name = "--decorations",
         .rc_name = "decorations",
-        .references = { (void *) &settings.deco_flags },
+        .struct_offset = offsetof(struct Settings, deco_flags),
 
         .pass = 1,
 
@@ -617,15 +607,14 @@ struct Param params[] = {
         .max_argc = 1,
 
         .default_argc = 1,
-        .default_argv = { "all" },
+        .default_argv = {"all"},
 
-        .parser = (param_parser_t) &parse_deco
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_deco,
+        .reloadable = True},
+    {.short_name = NULL,
         .long_name = "--dockapp-mode",
         .rc_name = "dockapp_mode",
-        .references = { (void *) &settings.dockapp_mode },
+        .struct_offset = offsetof(struct Settings, dockapp_mode),
 
         .pass = 1,
 
@@ -633,15 +622,13 @@ struct Param params[] = {
         .max_argc = 1,
 
         .default_argc = 1,
-        .default_argv = { "simple" },
+        .default_argv = {"simple"},
 
-        .parser = (param_parser_t) &parse_dockapp_mode
-    },
-    {
-        .short_name = "-f",
+        .parser = (param_parser_t)&parse_dockapp_mode},
+    {.short_name = "-f",
         .long_name = "--fuzzy-edges",
         .rc_name = "fuzzy_edges",
-        .references = { (void *) &settings.fuzzy_edges },
+        .struct_offset = offsetof(struct Settings, fuzzy_edges),
 
         .pass = 1,
 
@@ -649,15 +636,14 @@ struct Param params[] = {
         .max_argc = 1,
 
         .default_argc = 1,
-        .default_argv = { "2" },
+        .default_argv = {"2"},
 
-        .parser = (param_parser_t) &parse_int
-    },
-    {
-        .short_name = "-geometry",
+        .parser = (param_parser_t)&parse_int,
+        .reloadable = True},
+    {.short_name = "-geometry",
         .long_name = "--geometry",
         .rc_name = "geometry",
-        .references = { (void *) &settings.geometry_str },
+        .struct_offset = offsetof(struct Settings, geometry_str),
 
         .pass = 1,
 
@@ -667,13 +653,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_copystr
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_copystr},
+    {.short_name = NULL,
         .long_name = "--grow-gravity",
         .rc_name = "grow_gravity",
-        .references = { (void *) &settings.grow_gravity },
+        .struct_offset = offsetof(struct Settings, grow_gravity),
 
         .pass = 1,
 
@@ -683,13 +667,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_gravity
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_gravity},
+    {.short_name = NULL,
         .long_name = "--icon-gravity",
         .rc_name = "icon_gravity",
-        .references = { (void *) &settings.icon_gravity },
+        .struct_offset = offsetof(struct Settings, icon_gravity),
 
         .pass = 1,
 
@@ -699,13 +681,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_gravity
-    },
-    {
-        .short_name = "-i",
+        .parser = (param_parser_t)&parse_gravity},
+    {.short_name = "-i",
         .long_name = "--icon-size",
         .rc_name = "icon_size",
-        .references = { (void *) &settings.icon_size },
+        .struct_offset = offsetof(struct Settings, icon_size),
 
         .pass = 1,
 
@@ -715,13 +695,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_int
-    },
-    {
-        .short_name = "-h",
+        .parser = (param_parser_t)&parse_int},
+    {.short_name = "-h",
         .long_name = "--help",
         .rc_name = NULL,
-        .references = { (void *) &settings.need_help },
+        .struct_offset = offsetof(struct Settings, need_help),
 
         .pass = 0,
 
@@ -731,13 +709,11 @@ struct Param params[] = {
         .default_argc = 1,
         .default_argv = {"true"},
 
-        .parser = (param_parser_t) &parse_bool
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_bool},
+    {.short_name = NULL,
         .long_name = "--kludges",
         .rc_name = "kludges",
-        .references = { (void *) &settings.kludge_flags },
+        .struct_offset = offsetof(struct Settings, kludge_flags),
 
         .pass = 1,
 
@@ -747,13 +723,12 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_kludges
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_kludges,
+        .reloadable = True},
+    {.short_name = NULL,
         .long_name = "--max-geometry",
         .rc_name = "max_geometry",
-        .references = { (void *) &settings.max_geometry_str },
+        .struct_offset = offsetof(struct Settings, max_geometry_str),
 
         .pass = 1,
 
@@ -763,14 +738,12 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_copystr
-    },
+        .parser = (param_parser_t)&parse_copystr},
 #ifdef _ST_WITH_XINERAMA
-    {
-        .short_name = "-m",
+    {.short_name = "-m",
         .long_name = "--monitor",
         .rc_name = "monitor",
-        .references = { (void *) &settings.monitor },
+        .struct_offset = offsetof(struct Settings, monitor),
 
         .pass = 1,
 
@@ -780,14 +753,13 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_int
-    },
+        .parser = (param_parser_t)&parse_int,
+        .reloadable = True},
 #endif
-    {
-        .short_name = NULL,
+    {.short_name = NULL,
         .long_name = "--no-shrink",
         .rc_name = "no_shrink",
-        .references = { (void *) &settings.shrink_back_mode },
+        .struct_offset = offsetof(struct Settings, shrink_back_mode),
 
         .pass = 1,
 
@@ -797,13 +769,12 @@ struct Param params[] = {
         .default_argc = 1,
         .default_argv = {"true"},
 
-        .parser = (param_parser_t) &parse_bool_rev
-    },
-    {
-        .short_name = "-p",
+        .parser = (param_parser_t)&parse_bool_rev,
+        .reloadable = True},
+    {.short_name = "-p",
         .long_name = "--parent-bg",
         .rc_name = "parent_bg",
-        .references = { (void *) &settings.parent_bg },
+        .struct_offset = offsetof(struct Settings, parent_bg),
 
         .pass = 1,
 
@@ -813,13 +784,12 @@ struct Param params[] = {
         .default_argc = 1,
         .default_argv = {"true"},
 
-        .parser = (param_parser_t) &parse_bool
-    },
-    {
-        .short_name = "-r",
+        .parser = (param_parser_t)&parse_bool,
+        .reloadable = True},
+    {.short_name = "-r",
         .long_name = "--remote-click-icon",
         .rc_name = NULL,
-        .references = { (void *) &settings.remote_click_name },
+        .struct_offset = offsetof(struct Settings, remote_click_name),
 
         .pass = 1,
 
@@ -829,13 +799,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_copystr
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_copystr},
+    {.short_name = NULL,
         .long_name = "--remote-click-button",
         .rc_name = NULL,
-        .references = { (void *) &settings.remote_click_btn },
+        .struct_offset = offsetof(struct Settings, remote_click_btn),
 
         .pass = 1,
 
@@ -845,13 +813,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_int
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_int},
+    {.short_name = NULL,
         .long_name = "--remote-click-position",
         .rc_name = NULL,
-        .references = { (void *) &settings.remote_click_pos },
+        .struct_offset = offsetof(struct Settings, remote_click_pos),
 
         .pass = 1,
 
@@ -861,13 +827,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_pos
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_pos},
+    {.short_name = NULL,
         .long_name = "--remote-click-type",
         .rc_name = NULL,
-        .references = { (void *) &settings.remote_click_cnt },
+        .struct_offset = offsetof(struct Settings, remote_click_cnt),
 
         .pass = 1,
 
@@ -877,13 +841,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_remote_click_type
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_remote_click_type},
+    {.short_name = NULL,
         .long_name = "--scrollbars",
         .rc_name = "scrollbars",
-        .references = { (void *) &settings.scrollbars_mode },
+        .struct_offset = offsetof(struct Settings, scrollbars_mode),
 
         .pass = 1,
 
@@ -893,13 +855,12 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_sb_mode
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_sb_mode},
+    {.short_name = NULL,
         .long_name = "--scrollbars-highlight",
         .rc_name = "scrollbars_highlight",
-        .references = { (void *) &settings.scrollbars_highlight_color_str },
+        .struct_offset =
+            offsetof(struct Settings, scrollbars_highlight_color_str),
 
         .pass = 1,
 
@@ -909,13 +870,12 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_scrollbars_highlight_color
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_scrollbars_highlight_color,
+        .reloadable = True},
+    {.short_name = NULL,
         .long_name = "--scrollbars-step",
         .rc_name = "scrollbars_step",
-        .references = { (void *) &settings.scrollbars_inc },
+        .struct_offset = offsetof(struct Settings, scrollbars_inc),
 
         .pass = 1,
 
@@ -925,13 +885,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_int
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_int},
+    {.short_name = NULL,
         .long_name = "--scrollbars-size",
         .rc_name = "scrollbars_size",
-        .references = { (void *) &settings.scrollbars_size },
+        .struct_offset = offsetof(struct Settings, scrollbars_size),
 
         .pass = 1,
 
@@ -941,13 +899,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_int
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_int},
+    {.short_name = NULL,
         .long_name = "--scroll-everywhere",
         .rc_name = "scroll_everywhere",
-        .references = { (void *) &settings.scroll_everywhere },
+        .struct_offset = offsetof(struct Settings, scroll_everywhere),
 
         .pass = 1,
 
@@ -957,13 +913,12 @@ struct Param params[] = {
         .default_argc = 1,
         .default_argv = {"true"},
 
-        .parser = (param_parser_t) &parse_bool
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_bool,
+        .reloadable = True},
+    {.short_name = NULL,
         .long_name = "--drag-reorder",
         .rc_name = "drag_reorder",
-        .references = { (void *) &settings.drag_reorder },
+        .struct_offset = offsetof(struct Settings, drag_reorder),
 
         .pass = 1,
 
@@ -973,13 +928,11 @@ struct Param params[] = {
         .default_argc = 1,
         .default_argv = {"true"},
 
-        .parser = (param_parser_t) &parse_bool
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_bool},
+    {.short_name = NULL,
         .long_name = "--drag-modifier",
         .rc_name = "drag_modifier",
-        .references = { (void *) &settings.drag_modifier },
+        .struct_offset = offsetof(struct Settings, drag_modifier),
 
         .pass = 1,
 
@@ -989,13 +942,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_modifier
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_modifier},
+    {.short_name = NULL,
         .long_name = "--remember-icon-order",
         .rc_name = "remember_icon_order",
-        .references = { (void *) &settings.remember_icon_order },
+        .struct_offset = offsetof(struct Settings, remember_icon_order),
 
         .pass = 1,
 
@@ -1005,13 +956,11 @@ struct Param params[] = {
         .default_argc = 1,
         .default_argv = {"true"},
 
-        .parser = (param_parser_t) &parse_bool
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_bool},
+    {.short_name = NULL,
         .long_name = "--icon-order-file",
         .rc_name = "icon_order_file",
-        .references = { (void *) &settings.icon_order_file },
+        .struct_offset = offsetof(struct Settings, icon_order_file),
 
         .pass = 1,
 
@@ -1021,13 +970,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_copystr
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_copystr},
+    {.short_name = NULL,
         .long_name = "--icon-order-timeout",
         .rc_name = "icon_order_timeout",
-        .references = { (void *) &settings.icon_order_timeout },
+        .struct_offset = offsetof(struct Settings, icon_order_timeout),
 
         .pass = 1,
 
@@ -1037,13 +984,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_int
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_int},
+    {.short_name = NULL,
         .long_name = "--skip-taskbar",
         .rc_name = "skip_taskbar",
-        .references = { (void *) &settings.skip_taskbar },
+        .struct_offset = offsetof(struct Settings, skip_taskbar),
 
         .pass = 1,
 
@@ -1053,13 +998,12 @@ struct Param params[] = {
         .default_argc = 1,
         .default_argv = {"true"},
 
-        .parser = (param_parser_t) &parse_bool
-    },
-    {
-        .short_name = "-s",
+        .parser = (param_parser_t)&parse_bool,
+        .reloadable = True},
+    {.short_name = "-s",
         .long_name = "--slot-size",
         .rc_name = "slot_size",
-        .references = { (void *) &settings.slot_size },
+        .struct_offset = offsetof(struct Settings, slot_size),
 
         .pass = 1,
 
@@ -1069,13 +1013,11 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_size
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_size},
+    {.short_name = NULL,
         .long_name = "--sticky",
         .rc_name = "sticky",
-        .references = { (void *) &settings.sticky },
+        .struct_offset = offsetof(struct Settings, sticky),
 
         .pass = 1,
 
@@ -1085,13 +1027,12 @@ struct Param params[] = {
         .default_argc = 1,
         .default_argv = {"true"},
 
-        .parser = (param_parser_t) &parse_bool
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_bool,
+        .reloadable = True},
+    {.short_name = NULL,
         .long_name = "--tint-color",
         .rc_name = "tint_color",
-        .references = { (void *) &settings.tint_color_str },
+        .struct_offset = offsetof(struct Settings, tint_color_str),
 
         .pass = 1,
 
@@ -1101,13 +1042,12 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_copystr
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_copystr,
+        .reloadable = True},
+    {.short_name = NULL,
         .long_name = "--tint-level",
         .rc_name = "tint_level",
-        .references = { (void *) &settings.tint_level },
+        .struct_offset = offsetof(struct Settings, tint_level),
 
         .pass = 1,
 
@@ -1117,13 +1057,12 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_int
-    },
-    {
-        .short_name = "-t",
+        .parser = (param_parser_t)&parse_int,
+        .reloadable = True},
+    {.short_name = "-t",
         .long_name = "--transparent",
         .rc_name = "transparent",
-        .references = { (void *) &settings.transparent },
+        .struct_offset = offsetof(struct Settings, transparent),
 
         .pass = 1,
 
@@ -1133,13 +1072,12 @@ struct Param params[] = {
         .default_argc = 1,
         .default_argv = {"true"},
 
-        .parser = (param_parser_t) &parse_bool
-    },
-    {
-        .short_name = "-v",
+        .parser = (param_parser_t)&parse_bool,
+        .reloadable = True},
+    {.short_name = "-v",
         .long_name = "--vertical",
         .rc_name = "vertical",
-        .references = { (void *) &settings.vertical },
+        .struct_offset = offsetof(struct Settings, vertical),
 
         .pass = 1,
 
@@ -1149,13 +1087,11 @@ struct Param params[] = {
         .default_argc = 1,
         .default_argv = {"true"},
 
-        .parser = (param_parser_t) &parse_bool
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_bool},
+    {.short_name = NULL,
         .long_name = "--window-layer",
         .rc_name = "window_layer",
-        .references = { (void *) &settings.wnd_layer },
+        .struct_offset = offsetof(struct Settings, wnd_layer),
 
         .pass = 1,
 
@@ -1165,13 +1101,12 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_wnd_layer
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_wnd_layer,
+        .reloadable = True},
+    {.short_name = NULL,
         .long_name = "--window-name",
         .rc_name = "window_name",
-        .references = { (void *) &settings.wnd_name },
+        .struct_offset = offsetof(struct Settings, wnd_name),
 
         .pass = 1,
 
@@ -1181,13 +1116,12 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_copystr
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_copystr,
+        .reloadable = True},
+    {.short_name = NULL,
         .long_name = "--window-strut",
         .rc_name = "window_strut",
-        .references = { (void *) &settings.wm_strut_mode },
+        .struct_offset = offsetof(struct Settings, wm_strut_mode),
 
         .pass = 1,
 
@@ -1197,13 +1131,12 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_strut_mode
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_strut_mode,
+        .reloadable = True},
+    {.short_name = NULL,
         .long_name = "--window-type",
         .rc_name = "window_type",
-        .references = { (void *) &settings.wnd_type },
+        .struct_offset = offsetof(struct Settings, wnd_type),
 
         .pass = 1,
 
@@ -1213,13 +1146,12 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_wnd_type
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_wnd_type,
+        .reloadable = True},
+    {.short_name = NULL,
         .long_name = "--xsync",
         .rc_name = "xsync",
-        .references = { (void *) &settings.xsync },
+        .struct_offset = offsetof(struct Settings, xsync),
 
         .pass = 1,
 
@@ -1229,13 +1161,11 @@ struct Param params[] = {
         .default_argc = 1,
         .default_argv = {"true"},
 
-        .parser = (param_parser_t) &parse_bool
-    },
-    {
-        .short_name = NULL,
+        .parser = (param_parser_t)&parse_bool},
+    {.short_name = NULL,
         .long_name = NULL,
         .rc_name = "ignore_classes",
-        .references = { (void *) &settings.ignored_classes },
+        .struct_offset = offsetof(struct Settings, ignored_classes),
 
         .pass = 1,
 
@@ -1245,15 +1175,14 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_ignored_classes
-    },
+        .parser = (param_parser_t)&parse_ignored_classes,
+        .reloadable = True},
 
 #ifdef DELAY_EMBEDDING_CONFIRMATION
-    {
-        .short_name = NULL,
+    {.short_name = NULL,
         .long_name = "--confirmation-delay",
         .rc_name = "confirmation_delay",
-        .references = { (void *) &settings.confirmation_delay },
+        .struct_offset = offsetof(struct Settings, confirmation_delay),
 
         .pass = 1,
 
@@ -1263,16 +1192,14 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_int
-    },
+        .parser = (param_parser_t)&parse_int},
 #endif
 
 #ifdef _ST_WITH_XPM
-    {
-        .short_name = NULL,
+    {.short_name = NULL,
         .long_name = "--pixmap-bg",
         .rc_name = "pixmap_bg",
-        .references = { (void *) &settings.bg_pmap_path },
+        .struct_offset = offsetof(struct Settings, bg_pmap_path),
 
         .pass = 1,
 
@@ -1282,9 +1209,14 @@ struct Param params[] = {
         .default_argc = 0,
         .default_argv = NULL,
 
-        .parser = (param_parser_t) &parse_copystr
-    },
+        .parser = (param_parser_t)&parse_copystr,
+        .reloadable = True},
 #endif
+    /* Explicit sentinel: the loop `for (p = params; p->parser != NULL; ...)`
+     * needs a terminator. Trailing zeroed memory used to do the trick, but
+     * tools like AddressSanitizer surround globals with redzones and trip on
+     * the read past the last entry. */
+    {.parser = NULL},
 };
 
 void usage(char *progname)
@@ -1431,9 +1363,14 @@ void usage(char *progname)
         "\n");
 }
 
-/* Parse command line parameters */
+/* Parse command line parameters.
+ *
+ * Same self-tracking pattern as parse_rc: a static `reloading` flag flips on
+ * after the first call so subsequent invocations skip non-reloadable params
+ * and don't re-strdup values we'd never adopt. */
 int parse_cmdline(int argc, char **argv, int pass)
 {
+    static int reloading = 0;
     struct Param *p, *match;
     char *progname = argv[0];
     const char **p_argv = NULL, *argbuf[MAX_DEFAULT_ARGS];
@@ -1501,6 +1438,12 @@ int parse_cmdline(int argc, char **argv, int pass)
 
         if (match == NULL) USAGE_AND_DIE();
         if (match->pass != pass) continue;
+        if (reloading && !match->reloadable) {
+            LOG_TRACE(("cmdline: skipping non-reloadable param \"%s\"\n",
+                match->long_name != NULL ? match->long_name
+                                         : match->short_name));
+            continue;
+        }
         if (p_argv == NULL) DIE_IE(("Argument cannot be NULL!\n"));
 
         LOG_TRACE(("cmdline: pass %d, param \"%s\", args: [", pass, match->long_name != NULL ? match->long_name : match->short_name));
@@ -1510,10 +1453,10 @@ int parse_cmdline(int argc, char **argv, int pass)
 
         LOG_TRACE(("\"%s\"]\n", p_argv[p_argc - 1]));
 
-        if (!match->parser(p_argc, p_argv, match->references, match->min_argc == 0)) {
+        if (!match->parser(p_argc, p_argv, match->struct_offset, match->min_argc == 0)) {
             if (match->min_argc == 0) {
                 assert(p_argv != match->default_argv);
-                match->parser(match->default_argc, match->default_argv, match->references, False);
+                match->parser(match->default_argc, match->default_argv, match->struct_offset, False);
                 argc++;
                 argv--;
             } else
@@ -1526,6 +1469,8 @@ int parse_cmdline(int argc, char **argv, int pass)
         exit(0);
     }
 
+    /* From here on, subsequent calls behave as reloads. */
+    reloading = 1;
     return SUCCESS;
 }
 
@@ -1610,46 +1555,128 @@ int get_args(char *line, int *argc, char ***argv)
     return SUCCESS;
 }
 
+/* Locate a config file by joining the given path components and stat()ing
+ * the result. Returns a freshly-allocated path on success, NULL otherwise --
+ * the heap allocation keeps settings.config_fname uniformly heap-owned
+ * regardless of how it was populated. */
 char *find_rc(const char *path_part1, const char *path_part2, const char *rc)
 {
-    static char full_path[PATH_MAX];
+    char buf[PATH_MAX];
     int len;
     struct stat statbuf;
 
     if (path_part1 == NULL) return NULL;
     if (path_part2 == NULL) {
         LOG_TRACE(("looking for config file in '%s/%s'\n", path_part1, rc));
-        len = snprintf(full_path, sizeof(full_path), "%s/%s", path_part1, rc);
+        len = snprintf(buf, sizeof(buf), "%s/%s", path_part1, rc);
     } else {
         LOG_TRACE(("looking for config file in '%s/%s/%s'\n", path_part1,
             path_part2, rc));
-        len = snprintf(full_path, sizeof(full_path), "%s/%s/%s", path_part1,
-            path_part2, rc);
+        len = snprintf(buf, sizeof(buf), "%s/%s/%s", path_part1, path_part2, rc);
     }
 
-    if (len < 0 || (size_t) len >= sizeof(full_path)) return NULL;
-    if (stat(full_path, &statbuf) != 0) return NULL;
+    if (len < 0 || (size_t) len >= sizeof(buf)) return NULL;
+    if (stat(buf, &statbuf) != 0) return NULL;
 
-    return full_path;
+    return xstrdup(buf);
 }
 
 #define READ_BUF_SZ 512
-/* Parses rc file (path is either taken from settings.config_fname
- * or ~/.stalonetrayrc is used) */
-void parse_rc(void)
+
+/* Reports a parse error for the current rc-file line. On the first parse_rc
+ * call (startup load) it DIEs so misconfigured files surface loudly; on a
+ * subsequent call (a SIGHUP-driven reload) it only logs so a typo in a live
+ * edit can't take down the running tray. The caller decides what comes
+ * after a logged error -- usually setting rc = FAILURE and letting the
+ * surrounding parse loop unwind. */
+#define PARSE_ERROR(reloading, lnum, fmt, ...) \
+    do { \
+        if (reloading) { \
+            LOG_ERROR(("reload: %s:%d: " fmt, settings.config_fname, lnum, \
+                ##__VA_ARGS__)); \
+        } else { \
+            DIE(("Configuration file parse error at %s:%d: " fmt, \
+                settings.config_fname, lnum, ##__VA_ARGS__)); \
+        } \
+    } while (0)
+
+/* Parses a single rc-file line that has already been read into `buf`.
+ * Owns the lifetime of the argv that get_args() allocates. Returns SUCCESS
+ * for a valid directive (including one silently skipped on a reload because
+ * its param is non-reloadable), an empty line, or a comment-only line.
+ * Returns FAILURE only in reload mode after PARSE_ERROR has logged. */
+static int parse_rc_line(char *buf, int lnum, int reloading)
 {
-    FILE *cfg;
+    int argc, rc = SUCCESS;
+    char **argv = NULL;
+    struct Param *p, *match = NULL;
 
-    char buf[READ_BUF_SZ + 1];
+    if (!get_args(buf, &argc, &argv)) {
+        PARSE_ERROR(reloading, lnum, "could not parse line\n");
+        rc = FAILURE;
+    } else if (argc > 0) {
+        for (p = params; p->parser != NULL; p++)
+            if (p->rc_name != NULL && strcmp(argv[0], p->rc_name) == 0) {
+                match = p;
+                break;
+            }
+
+        if (match == NULL) {
+            PARSE_ERROR(reloading, lnum,
+                "unrecognized rc file keyword \"%s\".\n", argv[0]);
+            rc = FAILURE;
+        } else if (argc - 1 < match->min_argc
+            || (match->max_argc && argc - 1 > match->max_argc)) {
+            PARSE_ERROR(reloading, lnum,
+                "invalid number of args for \"%s\" (%d-%d required)\n",
+                match->rc_name, match->min_argc, match->max_argc);
+            rc = FAILURE;
+        } else if (reloading && !match->reloadable) {
+            LOG_TRACE(("rc: skipping non-reloadable param \"%s\"\n",
+                match->rc_name));
+        } else {
+            int p_argc = argc - 1;
+            const char **p_argv = (const char **) argv + 1;
+            if (p_argc == 0) {
+                p_argc = match->default_argc;
+                p_argv = match->default_argv;
+            }
+
+            LOG_TRACE(("rc: param \"%s\", args [\"", match->rc_name));
+            for (int i = 0; i < p_argc - 1; i++)
+                LOG_TRACE(("\"%s\", ", p_argv[i]));
+            LOG_TRACE(("\"%s\"]\n", p_argv[p_argc - 1]));
+
+            if (!match->parser(
+                    p_argc, p_argv, match->struct_offset, False)) {
+                PARSE_ERROR(reloading, lnum,
+                    "could not parse argument for \"%s\".\n", argv[0]);
+                rc = FAILURE;
+            }
+        }
+    }
+
+    free(argv);
+    return rc;
+}
+
+/* Parses the active rc file into *parse_target.
+ *
+ * Tracks whether this is the first call ("loading") or a subsequent one
+ * ("reloading") via a static flag so the function can apply slightly
+ * different behavior on a SIGHUP-driven reload without leaking that detail
+ * into the public API. On reloads we (a) skip params with reloadable == 0
+ * inside parse_rc_line(), and (b) downgrade fatal errors to a logged
+ * FAILURE so a malformed live edit doesn't take down the tray. The first
+ * load preserves the original strict behavior and DIEs on errors. */
+int parse_rc(void)
+{
+    static int reloading = 0;
+    FILE *cfg = NULL;
+    int rc = SUCCESS;
     int lnum = 0;
+    char buf[READ_BUF_SZ + 1];
 
-    int argc, p_argc;
-    char **argv;
-    const char **p_argv;
-
-    struct Param *p, *match;
-
-    /* 1. Setup file name */
     if (settings.config_fname == NULL)
         settings.config_fname =
             find_rc(getenv("HOME"), NULL, "." STALONETRAY_RC);
@@ -1659,86 +1686,34 @@ void parse_rc(void)
     if (settings.config_fname == NULL)
         settings.config_fname =
             find_rc(getenv("HOME"), ".config", STALONETRAY_RC);
+
     if (settings.config_fname == NULL) {
         LOG_INFO(("could not find any config files.\n"));
-        return;
-    }
-
-    LOG_INFO(("using config file \"%s\"\n", settings.config_fname));
-
-    /* 2. Open file */
-    cfg = fopen(settings.config_fname, "r");
-    if (cfg == NULL) {
+        /* On reload, treat a vanished config as a soft failure so the caller
+         * keeps the live settings instead of falling back to defaults. */
+        if (reloading) rc = FAILURE;
+    } else if ((cfg = fopen(settings.config_fname, "r")) == NULL) {
         LOG_ERROR(("could not open %s (%s)\n", settings.config_fname,
             strerror(errno)));
-        return;
-    }
-
-    /* 3. Read the file line by line */
-    buf[READ_BUF_SZ] = 0;
-    while (!feof(cfg)) {
-        lnum++;
-        if (fgets(buf, READ_BUF_SZ, cfg) == NULL) {
-            if (ferror(cfg)) LOG_ERROR(("read error (%s)\n", strerror(errno)));
-            break;
-        }
-
-        if (!get_args(buf, &argc, &argv)) {
-            DIE(("Configuration file parse error at %s:%d: could not parse "
-                 "line\n",
-                settings.config_fname, lnum));
-        }
-        if (!argc) continue; /* This is empty/comment-only line */
-
-        match = NULL;
-        p_argc = argc - 1;
-        p_argv = (const char **) argv + 1;
-
-        for (p = params; p->parser != NULL; p++) {
-            if (p->rc_name != NULL && strcmp(argv[0], p->rc_name) == 0) {
-                if (argc - 1 < p->min_argc || (p->max_argc && argc - 1 > p->max_argc)) {
-                    DIE(("Configuration file parse error at %s:%d: "
-                         "invalid number of args for \"%s\" (%d-%d required)\n",
-                        settings.config_fname, lnum,
-                        p->rc_name, p->min_argc, p->max_argc));
-                }
-
-                match = p;
-
-                if (p_argc == 0) {
-                    p_argc = match->default_argc;
-                    p_argv = match->default_argv;
-                }
-
+        if (reloading) rc = FAILURE;
+    } else {
+        LOG_INFO(("using config file \"%s\"\n", settings.config_fname));
+        buf[READ_BUF_SZ] = 0;
+        while (rc == SUCCESS && !feof(cfg)) {
+            lnum++;
+            if (fgets(buf, READ_BUF_SZ, cfg) == NULL) {
+                if (ferror(cfg))
+                    LOG_ERROR(("read error (%s)\n", strerror(errno)));
                 break;
             }
+            rc = parse_rc_line(buf, lnum, reloading);
         }
-
-        if (!match) {
-            DIE(("Configuration file parse error at %s:%d: unrecognized rc "
-                 "file keyword \"%s\".\n",
-                settings.config_fname, lnum, argv[0]));
-        }
-
-        assert(p_argv != NULL);
-
-        LOG_TRACE(("rc: param \"%s\", args [\"", match->rc_name));
-
-        for (int i = 0; i < p_argc - 1; i++)
-            LOG_TRACE(("\"%s\", ", p_argv[i]));
-
-        LOG_TRACE(("\"%s\"]\n", p_argv[p_argc - 1]));
-
-        if (!match->parser(p_argc, p_argv, match->references, False)) {
-            DIE(("Configuration file parse error at %s:%d: could not parse "
-                 "argument for \"%s\".\n",
-                settings.config_fname, lnum, argv[0]));
-        }
-
-        free(argv);
+        fclose(cfg);
     }
 
-    fclose(cfg);
+    /* From here on, the function behaves as a reload. */
+    reloading = 1;
+    return rc;
 }
 
 /* Interpret all settings that need an open display or other settings */
@@ -1883,6 +1858,132 @@ void interpret_settings(void)
         &tray_data.scrollbars_data.scroll_base.y);
     tray_data.scrollbars_data.scroll_base.x /= 2;
     tray_data.scrollbars_data.scroll_base.y /= 2;
+}
+
+void free_window_class_list(struct WindowClass *head)
+{
+    struct WindowClass *c, *next;
+    for (c = head; c != NULL; c = next) {
+        next = c->next;
+        free(c->name);
+        free(c);
+    }
+}
+
+int settings_reload(int argc, char **argv, struct Settings *out_old)
+{
+    /* Parse a fresh set of values into a scratch struct without touching the
+     * live settings yet. parse_target redirects every parser's writes here. */
+    struct Settings tmp = {0};
+    XColor tmp_color;
+    int ok;
+
+    parse_target = &tmp;
+    init_default_settings();
+    parse_cmdline(argc, argv, 0);
+    ok = parse_rc();
+    parse_target = &settings;
+    if (ok != SUCCESS) {
+        /* Syntax error / missing config / etc. tmp may be partially
+         * populated; free everything in it and leave the live settings
+         * untouched. */
+        free_settings(&tmp);
+        memset(out_old, 0, sizeof(*out_old));
+        return FAILURE;
+    }
+    parse_target = &tmp;
+    parse_cmdline(argc, argv, 1);
+    parse_target = &settings;
+
+    /* Snapshot live settings (shallow). out_old now aliases every live heap
+     * pointer; the transfers below carefully drop the aliases for fields we
+     * leave alone so the caller can free_settings(out_old) blindly. */
+    *out_old = settings;
+
+    /* Heap fields that are not reloadable stay in live `settings`; clear the
+     * aliases from out_old so free_settings(out_old) doesn't free strings
+     * still owned by `settings`. */
+    out_old->display_str = NULL;
+    out_old->geometry_str = NULL;
+    out_old->max_geometry_str = NULL;
+    out_old->config_fname = NULL;
+    out_old->icon_order_file = NULL;
+    out_old->remote_click_name = NULL;
+
+    /* For reloadable fields, move the freshly-parsed value from tmp into
+     * live settings. The pre-reload value (still aliased by out_old after
+     * the shallow snapshot above) is no longer referenced by `settings`, so
+     * the caller's free_settings(out_old) is what releases it. */
+#define ADOPT(f) \
+    do { \
+        settings.f = tmp.f; \
+        tmp.f = (__typeof__(tmp.f)) 0; \
+    } while (0)
+    ADOPT(log_level);
+    ADOPT(min_space_policy);
+    ADOPT(full_pmt_search);
+    ADOPT(shrink_back_mode);
+    ADOPT(kludge_flags);
+    ADOPT(scroll_everywhere);
+#ifdef _ST_WITH_XINERAMA
+    ADOPT(monitor);
+#endif
+    ADOPT(wm_strut_mode);
+    ADOPT(sticky);
+    ADOPT(skip_taskbar);
+    ADOPT(deco_flags);
+    ADOPT(fuzzy_edges);
+    ADOPT(tint_level);
+    ADOPT(transparent);
+    ADOPT(parent_bg);
+    ADOPT(bg_pmap_path);
+    ADOPT(bg_color_str);
+    ADOPT(tint_color_str);
+    ADOPT(scrollbars_highlight_color_str);
+    ADOPT(wnd_name);
+    ADOPT(wnd_layer);
+    ADOPT(wnd_type);
+    ADOPT(ignored_classes);
+#undef ADOPT
+
+    /* Discard non-reloadable values tmp accumulated (e.g. defaults assigned
+     * by init_default_settings or cmdline overrides parse_cmdline let
+     * through before the reloading flag flipped on the first call). */
+    free_settings(&tmp);
+
+    /* Mirror interpret_settings()'s derivations for the fields we just
+     * adopted, so the apply step downstream sees a coherent state. */
+    val_range(settings.tint_level, 0, 255);
+    val_range(settings.fuzzy_edges, 0, 3);
+#ifdef _ST_WITH_XPM
+    settings.pixmap_bg = (settings.bg_pmap_path != NULL);
+#endif
+    if (settings.pixmap_bg) {
+        settings.parent_bg = False;
+        settings.transparent = False;
+    }
+    if (settings.transparent) settings.parent_bg = False;
+
+    /* Re-parse colors into a temporary first; on parse failure leave the
+     * old XColor in place so the tray doesn't end up with a garbage pixel.
+     * (Skip silently if no live display is available, e.g. inside tests.) */
+    if (tray_data.dpy != NULL) {
+        if (x11_parse_color(tray_data.dpy, settings.bg_color_str, &tmp_color))
+            settings.bg_color = tmp_color;
+        else
+            LOG_ERROR(("reload: could not parse background color \"%s\"\n",
+                settings.bg_color_str));
+        if (settings.tint_level
+            && x11_parse_color(
+                tray_data.dpy, settings.tint_color_str, &tmp_color))
+            settings.tint_color = tmp_color;
+        if (settings.scrollbars_highlight_color_str != NULL
+            && x11_parse_color(tray_data.dpy,
+                settings.scrollbars_highlight_color_str, &tmp_color))
+            settings.scrollbars_highlight_color = tmp_color;
+    }
+
+    return SUCCESS;
 }
 
 /************** "main" ***********/

--- a/src/settings.c
+++ b/src/settings.c
@@ -1654,10 +1654,19 @@ static int parse_rc_line(char *buf, int lnum, int reloading)
                 p_argv = match->default_argv;
             }
 
-            LOG_TRACE(("rc: param \"%s\", args [\"", match->rc_name));
-            for (int i = 0; i < p_argc - 1; i++)
-                LOG_TRACE(("\"%s\", ", p_argv[i]));
-            LOG_TRACE(("\"%s\"]\n", p_argv[p_argc - 1]));
+            {
+                char argbuf[512];
+                int apos = 0;
+                argbuf[0] = '\0';
+                for (int i = 0; i < p_argc; i++) {
+                    int an = snprintf(argbuf + apos, sizeof(argbuf) - apos,
+                        "%s\"%s\"", i > 0 ? ", " : "", p_argv[i]);
+                    if (an < 0 || (size_t) (apos + an) >= sizeof(argbuf)) break;
+                    apos += an;
+                }
+                LOG_TRACE(
+                    ("rc: param \"%s\", args [%s]\n", match->rc_name, argbuf));
+            }
 
             if (!match->parser(
                     p_argc, p_argv, match->struct_offset, False)) {

--- a/src/settings.c
+++ b/src/settings.c
@@ -10,7 +10,6 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 
-#include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <libgen.h>
@@ -522,8 +521,8 @@ struct Param {
     const int pass; /* 0th pass parameters are parsed before rc file, */
                     /* 1st pass parameters are parsed after it */
 
-    const int min_argc; /* minimum number of expected arguments */
-    const int max_argc; /* maximum number of expected arguments, 0 for unlimited */
+    const int min_argc; /* minimum number of values the parameter requires */
+    const int max_argc; /* maximum values: 0 = none (flag), -1 = unlimited */
 
     const int default_argc;                     /* number of default arguments, if present */
     const char *default_argv[MAX_DEFAULT_ARGS]; /* default arguments if none are given */
@@ -1170,7 +1169,7 @@ struct Param params[] = {
         .pass = 1,
 
         .min_argc = 1,
-        .max_argc = 0,
+        .max_argc = -1,
 
         .default_argc = 0,
         .default_argv = NULL,
@@ -1363,105 +1362,119 @@ void usage(char *progname)
         "\n");
 }
 
-/* Parse command line parameters.
+/* Find the params[] entry a command-line token selects, or NULL if none.
  *
- * Same self-tracking pattern as parse_rc: a static `reloading` flag flips on
- * after the first call so subsequent invocations skip non-reloadable params
- * and don't re-strdup values we'd never adopt. */
+ * Flags (max_argc 0) match by exact name. Value options match by name prefix
+ * so an attached value is recognized -- a short option carries it directly
+ * (-s8), a long one after '=' (--geometry=x) -- in which case *inline_val is
+ * pointed at it; otherwise *inline_val is NULL and the value, if any, is the
+ * following token. rc-only params have no command-line names and never match,
+ * which is what keeps an unknown option from being compared against a NULL
+ * name. */
+static struct Param *cmdline_match(const char *arg, const char **inline_val)
+{
+    struct Param *p;
+    *inline_val = NULL;
+
+    for (p = params; p->parser != NULL; p++) {
+        size_t slen = p->short_name != NULL ? strlen(p->short_name) : 0;
+        size_t llen = p->long_name != NULL ? strlen(p->long_name) : 0;
+        int is_short = slen != 0 && strncmp(arg, p->short_name, slen) == 0;
+        int is_long = llen != 0 && strncmp(arg, p->long_name, llen) == 0;
+
+        if (!is_short && !is_long)
+            continue;
+
+        if (p->max_argc == 0) {
+            if ((is_short && arg[slen] == 0) || (is_long && arg[llen] == 0))
+                return p;
+            continue;
+        }
+
+        if (is_short) {
+            if (arg[slen] != '\0')
+                *inline_val = arg + slen;
+            return p;
+        }
+
+        if (arg[llen] == '=')
+            *inline_val = arg + llen + 1;
+        else if (arg[llen] != '\0')
+            continue;
+
+        return p;
+    }
+
+    return NULL;
+}
+
+/* Parse one command-line pass.
+ *
+ * Each token is matched to a params[] entry; an unknown one prints the usage
+ * and exits. The option's value (an attached value, the next token, or its
+ * default) is resolved -- and any separate value token consumed -- before the
+ * pass/reload filters, so the value of an option belonging to the other pass
+ * is not mistaken for an option here. An option whose argument is optional and
+ * whose grabbed token fails to parse hands that token back for the loop to
+ * reconsider. A missing required value, or any other parse failure, exits.
+ *
+ * A static flag makes every call after the first behave as a reload, skipping
+ * non-reloadable options so their values are not re-parsed. */
 int parse_cmdline(int argc, char **argv, int pass)
 {
     static int reloading = 0;
-    struct Param *p, *match;
     char *progname = argv[0];
-    const char **p_argv = NULL, *argbuf[MAX_DEFAULT_ARGS];
-    int p_argc;
+    const char *slot[1];
 
     while (--argc > 0) {
-        argv++;
-        match = NULL;
-        for (p = params; p->parser != NULL; p++) {
-            if (p->max_argc) {
-                if (p->short_name != NULL && strstr(*argv, p->short_name) == *argv) {
-                    if ((*argv)[strlen(p->short_name)] != '\0') { /* accept arguments in the form -a5 */
-                        argbuf[0] = *argv + strlen(p->short_name);
-                        p_argc = 1;
-                        p_argv = argbuf;
-                    } else if (argc > 1 && argv[1][0] != '-') { /* accept arguments in the form -a 5, do not accept values starting with '-' */
-                        argbuf[0] = *(++argv);
-                        p_argc = 1;
-                        p_argv = argbuf;
-                        argc--;
-                    } else if (p->min_argc > 0) { /* argument is missing */
-                        LOG_ERROR(("%s expects an argument\n", p->short_name));
-                        break;
-                    } else { /* argument is optional, use default value */
-                        p_argc = p->default_argc;
-                        p_argv = p->default_argv;
-                    }
-                } else if (p->long_name != NULL && strstr(*argv, p->long_name) == *argv) {
-                    if ((*argv)[strlen(p->long_name)] == '=') {/* accept arguments in the form --abcd=5 */
-                        argbuf[0] = *argv + strlen(p->long_name) + 1;
-                        p_argc = 1;
-                        p_argv = argbuf;
-                    } else if ((*argv)[strlen(p->long_name)] == '\0') { /* accept arguments in the from --abcd 5 */
-                        if (argc > 1 && argv[1][0] != '-') { /* arguments cannot start with the dash */
-                            argbuf[0] = *(++argv);
-                            p_argc = 1;
-                            p_argv = argbuf;
-                            argc--;
-                        } else if (p->min_argc > 0) { /* argument is missing */
-                            LOG_ERROR(("%s expects an argument\n", p->long_name));
-                            break;
-                        } else { /* argument is optional, use default value */
-                            p_argc = p->default_argc;
-                            p_argv = p->default_argv;
-                        }
-                    } else
-                        continue; /* just in case when there can be both --abc and --abcd */
-                } else
-                    continue;
-                match = p;
-                break;
-            } else if (strcmp(*argv, p->short_name) == 0 || strcmp(*argv, p->long_name) == 0) {
-                match = p;
-                p_argc = p->default_argc;
-                p_argv = p->default_argv;
-                break;
-            }
+        char *arg = *(++argv);
+        const char *inline_val;
+        struct Param *match = cmdline_match(arg, &inline_val);
+        const char **values = NULL;
+        int count = 0, took_next = 0;
+
+        if (match == NULL) {
+            usage(progname);
+            DIE(("unknown command line option \"%s\"\n", arg));
         }
 
-#define USAGE_AND_DIE() \
-    do { \
-        usage(progname); \
-        DIE(("Could not parse command line\n")); \
-    } while (0)
+        if (inline_val != NULL) {
+            slot[0] = inline_val;
+            values = slot;
+            count = 1;
+        } else if (match->max_argc != 0 && argc > 1 && argv[1][0] != '-') {
+            slot[0] = *(++argv);
+            argc--;
+            took_next = 1;
+            values = slot;
+            count = 1;
+        } else if (match->min_argc > 0) {
+            usage(progname);
+            DIE(("%s expects an argument\n", arg));
+        } else {
+            values = match->default_argv;
+            count = match->default_argc;
+        }
 
-        if (match == NULL) USAGE_AND_DIE();
         if (match->pass != pass) continue;
-        if (reloading && !match->reloadable) {
-            LOG_TRACE(("cmdline: skipping non-reloadable param \"%s\"\n",
-                match->long_name != NULL ? match->long_name
-                                         : match->short_name));
+        if (reloading && !match->reloadable) continue;
+
+        LOG_TRACE(("cmdline: pass %d, option \"%s\"\n", pass, arg));
+
+        if (match->parser(
+                count, values, match->struct_offset, match->min_argc == 0))
+            continue;
+
+        if (match->min_argc == 0 && took_next) {
+            match->parser(match->default_argc, match->default_argv,
+                match->struct_offset, False);
+            argc++;
+            argv--;
             continue;
         }
-        if (p_argv == NULL) DIE_IE(("Argument cannot be NULL!\n"));
 
-        LOG_TRACE(("cmdline: pass %d, param \"%s\", args: [", pass, match->long_name != NULL ? match->long_name : match->short_name));
-
-        for (int i = 0; i < p_argc - 1; i++)
-            LOG_TRACE(("\"%s\", ", p_argv[i]));
-
-        LOG_TRACE(("\"%s\"]\n", p_argv[p_argc - 1]));
-
-        if (!match->parser(p_argc, p_argv, match->struct_offset, match->min_argc == 0)) {
-            if (match->min_argc == 0) {
-                assert(p_argv != match->default_argv);
-                match->parser(match->default_argc, match->default_argv, match->struct_offset, False);
-                argc++;
-                argv--;
-            } else
-                USAGE_AND_DIE();
-        }
+        usage(progname);
+        DIE(("could not parse argument for \"%s\"\n", arg));
     }
 
     if (settings.need_help) {
@@ -1469,7 +1482,6 @@ int parse_cmdline(int argc, char **argv, int pass)
         exit(0);
     }
 
-    /* From here on, subsequent calls behave as reloads. */
     reloading = 1;
     return SUCCESS;
 }
@@ -1626,7 +1638,7 @@ static int parse_rc_line(char *buf, int lnum, int reloading)
                 "unrecognized rc file keyword \"%s\".\n", argv[0]);
             rc = FAILURE;
         } else if (argc - 1 < match->min_argc
-            || (match->max_argc && argc - 1 > match->max_argc)) {
+            || (match->max_argc >= 0 && argc - 1 > match->max_argc)) {
             PARSE_ERROR(reloading, lnum,
                 "invalid number of args for \"%s\" (%d-%d required)\n",
                 match->rc_name, match->min_argc, match->max_argc);

--- a/src/settings.h
+++ b/src/settings.h
@@ -118,6 +118,10 @@ int read_settings(int argc, char **argv);
  * FAILURE. Exposed for testing -- normal code goes through read_settings or
  * settings_reload. */
 int parse_rc(void);
+/* Parse one command-line pass into the active settings target. An unknown
+ * option, a missing required value, or an unparseable value prints the usage
+ * and exits. Exposed for testing -- normal code goes through read_settings. */
+int parse_cmdline(int argc, char **argv, int pass);
 /* Interpret all settings that either need an
  * open display or are interpreted from other
  * settings */

--- a/src/settings.h
+++ b/src/settings.h
@@ -106,11 +106,42 @@ struct Settings {
 
 extern struct Settings settings;
 
+/* Populate the active settings target (`settings` by default) with default
+ * values, allocating any string defaults on the heap so ownership is
+ * uniform. Safe to call repeatedly; existing heap content is freed first. */
+void init_default_settings(void);
 /* Read settings from cmd line and configuration file */
 int read_settings(int argc, char **argv);
+/* Parse the rc file at settings.config_fname (or the default search path if
+ * NULL) into the active settings target. Returns SUCCESS / FAILURE; on the
+ * first call a syntax error DIEs, on later calls it logs and returns
+ * FAILURE. Exposed for testing -- normal code goes through read_settings or
+ * settings_reload. */
+int parse_rc(void);
 /* Interpret all settings that either need an
  * open display or are interpreted from other
  * settings */
 void interpret_settings();
+/* Free a linked list of WindowClass entries (each name and node). */
+void free_window_class_list(struct WindowClass *head);
+/* Release every heap-owned string in *s and the ignored_classes list, and
+ * zero the struct. Safe on a zero-initialized struct (free(NULL) is a no-op).
+ */
+void free_settings(struct Settings *s);
+/* Re-read the configuration file (and re-apply the original command line)
+ * to pick up changes made at runtime. Most settings are silently restored to
+ * their pre-reload value: only a curated subset (entries with reloadable == 1
+ * in settings.c's params[]) is adopted from the freshly parsed config.
+ *
+ * On success, returns SUCCESS and *out_old holds the pre-reload settings
+ * (shallow copy) for the caller to diff against the now-live settings and
+ * run any apply steps; the caller is also responsible for freeing
+ * out_old->ignored_classes once it has finished with it.
+ *
+ * On failure (parse error in the config file, or the file is gone), settings
+ * is restored to exactly what it was before the call, *out_old is left in a
+ * state where freeing out_old->ignored_classes is a safe no-op, and FAILURE
+ * is returned. The caller should skip the apply step. */
+int settings_reload(int argc, char **argv, struct Settings *out_old);
 
 #endif

--- a/src/tray.c
+++ b/src/tray.c
@@ -31,6 +31,11 @@
 
 #include "debug.h"
 
+/* The single global state struct. Declared in tray.h. Defined here (rather
+ * than in main.c) so tests that link only core_sources get the definition
+ * too. */
+struct TrayData tray_data;
+
 void tray_init()
 {
     tray_data.tray = None;

--- a/src/wmh.c
+++ b/src/wmh.c
@@ -83,6 +83,47 @@ int ewmh_add_window_state(Display *dpy, Window wnd, char *state)
     return rc;
 }
 
+/* Remove a previously-added EWMH window state */
+int ewmh_remove_window_state(Display *dpy, Window wnd, char *state)
+{
+    Atom prop;
+    Atom atom;
+    XWindowAttributes xwa;
+    int rc;
+    prop = XInternAtom(dpy, "_NET_WM_STATE", False);
+    atom = XInternAtom(dpy, state, False);
+    LOG_TRACE(("removing state %s from window 0x%lx\n", state, atom));
+    rc = XGetWindowAttributes(dpy, wnd, &xwa);
+    if (!x11_ok() || !rc) return FAILURE;
+
+    if (xwa.map_state != IsUnmapped && ewmh_wm_present(dpy)) {
+        return x11_send_client_msg32(
+            dpy, xwa.root, wnd, prop, _NET_WM_STATE_REMOVE, atom, 0, 0, 0);
+    }
+    /* No WM to ask; rewrite the property ourselves, dropping the atom. */
+    {
+        Atom *states = NULL, *kept = NULL;
+        unsigned long n = 0, kept_n = 0, i;
+        if (!x11_get_window_prop32(
+                dpy, wnd, prop, XA_ATOM, (unsigned char **) &states, &n))
+            return SUCCESS; /* property absent; nothing to remove */
+        if (n > 0) {
+            kept = malloc(n * sizeof(Atom));
+            if (kept == NULL) {
+                XFree(states);
+                return FAILURE;
+            }
+            for (i = 0; i < n; i++)
+                if (states[i] != atom) kept[kept_n++] = states[i];
+        }
+        XChangeProperty(dpy, wnd, prop, XA_ATOM, 32, PropModeReplace,
+            (unsigned char *) kept, (int) kept_n);
+        free(kept);
+        XFree(states);
+        return x11_ok();
+    }
+}
+
 /* Add EWMH window type for the given window */
 int ewmh_add_window_type(Display *dpy, Window wnd, char *type)
 {

--- a/src/wmh.h
+++ b/src/wmh.h
@@ -81,6 +81,8 @@ typedef unsigned long wm_strut_t[_NET_WM_STRUT_PARTIAL_SZ];
 int ewmh_wm_present(Display *dpy);
 /* Add window type for the window wnd */
 int ewmh_add_window_state(Display *dpy, Window wnd, char *state);
+/* Remove a previously-added window state */
+int ewmh_remove_window_state(Display *dpy, Window wnd, char *state);
 /* Add window type for the window wnd */
 int ewmh_add_window_type(Display *dpy, Window wnd, char *type);
 /* Set data for _NET_WM_STRUT_PARTIAL hint */

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,8 @@
+test_settings = executable(
+  'test_settings',
+  ['test_settings.c'] + core_sources,
+  c_args: build_args,
+  dependencies: _dependencies + [cmocka_dep],
+)
+
+test('settings', test_settings)

--- a/tests/test_settings.c
+++ b/tests/test_settings.c
@@ -1,0 +1,336 @@
+/* Unit tests for settings ownership and reload semantics.
+ *
+ * These tests exercise the settings module without an X display: settings.c
+ * and the rest of core_sources are linked, but tray_data.dpy stays NULL so
+ * the X-dependent code paths short-circuit. */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <setjmp.h> /* cmocka requires this before <cmocka.h> */
+#include <cmocka.h>
+
+#include "../src/settings.h"
+#include "../src/tray.h"
+
+/* Helper: write a temp rc file with the given body and point
+ * settings.config_fname at it. Caller is responsible for unlink+free via
+ * cleanup_tmp_rc(). */
+static char *write_tmp_rc(const char *body)
+{
+    char *path = strdup("/tmp/stalonetrayrc.test.XXXXXX");
+    int fd = mkstemp(path);
+    assert_true(fd >= 0);
+    ssize_t n = write(fd, body, strlen(body));
+    assert_true(n == (ssize_t) strlen(body));
+    close(fd);
+    return path;
+}
+
+static void cleanup_tmp_rc(char *path)
+{
+    if (path != NULL) {
+        unlink(path);
+        free(path);
+    }
+}
+
+/* Reset the global `settings` between tests, returning ownership of all the
+ * strdups init_default_settings allocated so the next test starts clean. */
+static int reset_settings(void **state)
+{
+    (void) state;
+    free_settings(&settings);
+    init_default_settings();
+    return 0;
+}
+
+static int teardown_settings(void **state)
+{
+    (void) state;
+    free_settings(&settings);
+    return 0;
+}
+
+/* ---------------------------------------------------------------- defaults */
+
+static void test_init_default_settings_strdups_strings(void **state)
+{
+    (void) state;
+    /* Defaults should be heap pointers, not the static literals previously
+     * baked into init_default_settings. The values themselves are still the
+     * documented defaults. */
+    assert_non_null(settings.bg_color_str);
+    assert_string_equal(settings.bg_color_str, "gray");
+    assert_non_null(settings.tint_color_str);
+    assert_string_equal(settings.tint_color_str, "white");
+    assert_non_null(settings.scrollbars_highlight_color_str);
+    assert_string_equal(settings.scrollbars_highlight_color_str, "white");
+    assert_non_null(settings.max_geometry_str);
+    assert_string_equal(settings.max_geometry_str, "0x0");
+    assert_non_null(settings.wnd_type);
+    assert_non_null(settings.wnd_name);
+
+    /* Some scalar defaults to make sure init isn't a complete no-op. */
+    assert_int_equal(settings.sticky, 1);
+    assert_int_equal(settings.skip_taskbar, 1);
+    assert_int_equal(settings.shrink_back_mode, 1);
+}
+
+/* --------------------------------------------------------------- free_settings */
+
+static void test_free_settings_zeroes_struct(void **state)
+{
+    (void) state;
+    free_settings(&settings);
+    assert_null(settings.bg_color_str);
+    assert_null(settings.tint_color_str);
+    assert_null(settings.wnd_type);
+    assert_null(settings.wnd_name);
+    assert_null(settings.ignored_classes);
+    /* Idempotent: a second free shouldn't crash. */
+    free_settings(&settings);
+}
+
+static void test_free_settings_safe_on_zero_init(void **state)
+{
+    (void) state;
+    /* Equivalent to a fresh on-stack snapshot: every pointer NULL. */
+    struct Settings blank = {0};
+    free_settings(&blank);  /* must not crash */
+    assert_null(blank.bg_color_str);
+}
+
+/* --------------------------------------------------------- settings_reload */
+
+/* Cover the round-trip: a reloadable setting in the config takes effect, a
+ * non-reloadable setting keeps its pre-reload value, and the out_old handed
+ * back can be free_settings()'d without double-freeing the live struct. */
+static void test_settings_reload_adopts_reloadable_keeps_others(void **state)
+{
+    (void) state;
+    /* Mutate two reloadable fields and one non-reloadable field so we can
+     * verify reload (a) overrides reloadable with the config value and (b)
+     * leaves the non-reloadable field alone even when the config touches it. */
+    free(settings.bg_color_str);
+    settings.bg_color_str = strdup("starting-bg");
+    settings.tint_level = 7;
+    settings.icon_size = 24;        /* non-reloadable */
+
+    char *rc_path = write_tmp_rc(
+        "background blue\n"
+        "tint_level 42\n"
+        "icon_size 99\n");
+    free(settings.config_fname);
+    settings.config_fname = strdup(rc_path);
+
+    char *argv[] = {(char *) "test"};
+    struct Settings old;
+    int rc = settings_reload(1, argv, &old);
+    assert_int_equal(rc, 1 /* SUCCESS */);
+
+    /* Reloadable fields adopt the config values. */
+    assert_string_equal(settings.bg_color_str, "blue");
+    assert_int_equal(settings.tint_level, 42);
+
+    /* Non-reloadable: parse_rc + parse_cmdline skip these on a reload, so the
+     * live value remains untouched (NOT 99 from the config). */
+    assert_int_equal(settings.icon_size, 24);
+
+    /* out_old keeps the pre-reload reloadable values for the caller's diff. */
+    assert_string_equal(old.bg_color_str, "starting-bg");
+    assert_int_equal(old.tint_level, 7);
+
+    /* Non-reloadable string slots in out_old must be NULL so this free is
+     * safe (otherwise it would alias still-live pointers in `settings`). */
+    assert_null(old.display_str);
+    assert_null(old.geometry_str);
+    assert_null(old.max_geometry_str);
+    assert_null(old.config_fname);
+
+    free_settings(&old);
+    cleanup_tmp_rc(rc_path);
+}
+
+/* On a malformed config we must not crash, must not touch the live settings,
+ * and must return FAILURE so the caller skips the apply step. */
+static void test_settings_reload_rolls_back_on_syntax_error(void **state)
+{
+    (void) state;
+    free(settings.bg_color_str);
+    settings.bg_color_str = strdup("preserved");
+
+    char *rc_path = write_tmp_rc("this_is_not_a_valid_keyword foo\n");
+    free(settings.config_fname);
+    settings.config_fname = strdup(rc_path);
+
+    char *argv[] = {(char *) "test"};
+    struct Settings old;
+    int rc = settings_reload(1, argv, &old);
+    assert_int_equal(rc, 0 /* FAILURE */);
+
+    /* Live setting is untouched; out_old is safe to free (all NULL). */
+    assert_string_equal(settings.bg_color_str, "preserved");
+    assert_null(old.bg_color_str);
+    free_settings(&old);
+
+    cleanup_tmp_rc(rc_path);
+}
+
+/* The unique-ownership invariant: after reload, the previous reloadable
+ * heap allocation is owned by out_old (not by settings) so freeing both is
+ * safe and doesn't double-free. */
+static void test_settings_reload_no_double_free(void **state)
+{
+    (void) state;
+    char *rc_path = write_tmp_rc("background green\n");
+    free(settings.config_fname);
+    settings.config_fname = strdup(rc_path);
+
+    char *argv[] = {(char *) "test"};
+    struct Settings old;
+    int rc = settings_reload(1, argv, &old);
+    assert_int_equal(rc, 1 /* SUCCESS */);
+    /* Same pointer would mean double-free territory. */
+    assert_ptr_not_equal(settings.bg_color_str, old.bg_color_str);
+
+    free_settings(&old);
+    /* If old.bg_color_str had aliased settings.bg_color_str, the next read
+     * would be a use-after-free. We just dereference it to make tools like
+     * valgrind / ASan flag the bug if it ever returns. */
+    assert_non_null(settings.bg_color_str);
+    assert_string_equal(settings.bg_color_str, "green");
+
+    cleanup_tmp_rc(rc_path);
+}
+
+/* ------------------------------------------------------------- parse_rc */
+
+/* Convenience: drop a one-liner rc into a temp file and point
+ * settings.config_fname at it, run parse_rc(), and clean up. */
+static int parse_rc_with_body(const char *body)
+{
+    char *path = write_tmp_rc(body);
+    free(settings.config_fname);
+    settings.config_fname = strdup(path);
+    int rc = parse_rc();
+    cleanup_tmp_rc(path);
+    return rc;
+}
+
+static void test_parse_rc_string_field(void **state)
+{
+    (void) state;
+    assert_int_equal(parse_rc_with_body("background salmon\n"), 1 /* SUCCESS */);
+    assert_string_equal(settings.bg_color_str, "salmon");
+}
+
+static void test_parse_rc_int_field(void **state)
+{
+    (void) state;
+    assert_int_equal(parse_rc_with_body("tint_level 123\n"), 1 /* SUCCESS */);
+    assert_int_equal(settings.tint_level, 123);
+}
+
+static void test_parse_rc_bool_field(void **state)
+{
+    (void) state;
+    /* sticky defaults to 1; verify the parser actually flips it. */
+    assert_int_equal(settings.sticky, 1);
+    assert_int_equal(parse_rc_with_body("sticky no\n"), 1 /* SUCCESS */);
+    assert_int_equal(settings.sticky, 0);
+}
+
+static void test_parse_rc_enum_field(void **state)
+{
+    (void) state;
+    /* window_type takes a symbolic name and stores the EWMH atom string. */
+    assert_int_equal(
+        parse_rc_with_body("window_type utility\n"), 1 /* SUCCESS */);
+    assert_string_equal(settings.wnd_type, "_NET_WM_WINDOW_TYPE_UTILITY");
+}
+
+static void test_parse_rc_list_field(void **state)
+{
+    (void) state;
+    assert_null(settings.ignored_classes);
+    assert_int_equal(
+        parse_rc_with_body("ignore_classes Mumble Discord rustdesk\n"),
+        1 /* SUCCESS */);
+
+    /* The list is built head-first by LIST_ADD_ITEM, so iteration order is
+     * the reverse of the rc file order. Just collect names into a set and
+     * make sure each one shows up. */
+    int saw_mumble = 0, saw_discord = 0, saw_rustdesk = 0, count = 0;
+    for (struct WindowClass *c = settings.ignored_classes; c != NULL;
+        c = c->next) {
+        count++;
+        if (strcmp(c->name, "Mumble") == 0) saw_mumble = 1;
+        else if (strcmp(c->name, "Discord") == 0) saw_discord = 1;
+        else if (strcmp(c->name, "rustdesk") == 0) saw_rustdesk = 1;
+    }
+    assert_int_equal(count, 3);
+    assert_true(saw_mumble && saw_discord && saw_rustdesk);
+}
+
+static void test_parse_rc_ignores_comments_and_blank_lines(void **state)
+{
+    (void) state;
+    int rc = parse_rc_with_body(
+        "# leading comment\n"
+        "\n"
+        "background turquoise\n"
+        "    # comment with leading whitespace\n"
+        "\n"
+        "tint_level 5\n");
+    assert_int_equal(rc, 1 /* SUCCESS */);
+    assert_string_equal(settings.bg_color_str, "turquoise");
+    assert_int_equal(settings.tint_level, 5);
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(
+            test_init_default_settings_strdups_strings, reset_settings,
+            teardown_settings),
+        cmocka_unit_test_setup_teardown(
+            test_free_settings_zeroes_struct, reset_settings,
+            teardown_settings),
+        cmocka_unit_test(test_free_settings_safe_on_zero_init),
+        cmocka_unit_test_setup_teardown(
+            test_settings_reload_adopts_reloadable_keeps_others,
+            reset_settings, teardown_settings),
+        cmocka_unit_test_setup_teardown(
+            test_settings_reload_rolls_back_on_syntax_error, reset_settings,
+            teardown_settings),
+        cmocka_unit_test_setup_teardown(
+            test_settings_reload_no_double_free, reset_settings,
+            teardown_settings),
+        /* parse_rc value-level tests. Pattern to extend: write a one-line
+         * rc with parse_rc_with_body(), then assert the field's new value
+         * on `settings`. Only reloadable params are guaranteed to be
+         * parsed here (parse_rc's static reloading flag flips to 1 after
+         * the first test above, and non-reloadable params get skipped
+         * from then on). */
+        cmocka_unit_test_setup_teardown(test_parse_rc_string_field,
+            reset_settings, teardown_settings),
+        cmocka_unit_test_setup_teardown(test_parse_rc_int_field,
+            reset_settings, teardown_settings),
+        cmocka_unit_test_setup_teardown(test_parse_rc_bool_field,
+            reset_settings, teardown_settings),
+        cmocka_unit_test_setup_teardown(test_parse_rc_enum_field,
+            reset_settings, teardown_settings),
+        cmocka_unit_test_setup_teardown(test_parse_rc_list_field,
+            reset_settings, teardown_settings),
+        cmocka_unit_test_setup_teardown(
+            test_parse_rc_ignores_comments_and_blank_lines, reset_settings,
+            teardown_settings),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/test_settings.c
+++ b/tests/test_settings.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include <setjmp.h> /* cmocka requires this before <cmocka.h> */
@@ -17,6 +18,11 @@
 
 #include "../src/settings.h"
 #include "../src/tray.h"
+
+/* Resolves to the LeakSanitizer hook under -fsanitize=address and to NULL
+ * otherwise, so the forked children below can opt out of leak reporting
+ * (they exit via _exit/exit without unwinding). */
+extern void __lsan_disable(void) __attribute__((weak));
 
 /* Helper: write a temp rc file with the given body and point
  * settings.config_fname at it. Caller is responsible for unlink+free via
@@ -293,9 +299,121 @@ static void test_parse_rc_ignores_comments_and_blank_lines(void **state)
     assert_int_equal(settings.tint_level, 5);
 }
 
+/* --------------------------------------------------------------- parse_cmdline */
+
+/* Run parse_cmdline over `argv` in a child process. parse_cmdline calls
+ * usage()+exit() on a bad option, so a child keeps that from taking down the
+ * test runner. The child's stderr (where the error message lands; usage()
+ * goes to stdout, discarded) is captured into `err`. Returns the child's exit
+ * status: 255 for the exit(-1) inside DIE, 0 for a clean parse. */
+static int run_cmdline(int argc, char **argv, char *err, size_t errsz)
+{
+    int fds[2];
+    pid_t pid;
+    ssize_t n;
+    int status = 0;
+
+    assert_int_equal(pipe(fds), 0);
+    pid = fork();
+    assert_true(pid >= 0);
+
+    if (pid == 0) {
+        if (__lsan_disable) __lsan_disable();
+        dup2(fds[1], STDERR_FILENO);
+        freopen("/dev/null", "w", stdout);
+        close(fds[0]);
+        close(fds[1]);
+        init_default_settings();
+        parse_cmdline(argc, argv, 0);
+        parse_cmdline(argc, argv, 1);
+        _exit(0);
+    }
+
+    close(fds[1]);
+    n = read(fds[0], err, errsz - 1);
+    err[n > 0 ? n : 0] = '\0';
+    close(fds[0]);
+    waitpid(pid, &status, 0);
+    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+}
+
+static void test_cmdline_unknown_long_option(void **state)
+{
+    (void) state;
+    char *argv[] = {(char *) "stalonetray", (char *) "--no-such-flag", NULL};
+    char err[1024];
+    assert_int_equal(run_cmdline(2, argv, err, sizeof(err)), 255);
+    assert_non_null(strstr(err, "unknown command line option"));
+    assert_non_null(strstr(err, "--no-such-flag"));
+}
+
+static void test_cmdline_unknown_short_option(void **state)
+{
+    (void) state;
+    char *argv[] = {(char *) "stalonetray", (char *) "-Q", NULL};
+    char err[1024];
+    assert_int_equal(run_cmdline(2, argv, err, sizeof(err)), 255);
+    assert_non_null(strstr(err, "unknown command line option"));
+    assert_non_null(strstr(err, "-Q"));
+}
+
+static void test_cmdline_missing_required_argument(void **state)
+{
+    (void) state;
+    char *argv[] = {(char *) "stalonetray", (char *) "--background", NULL};
+    char err[1024];
+    assert_int_equal(run_cmdline(2, argv, err, sizeof(err)), 255);
+    assert_non_null(strstr(err, "expects an argument"));
+    assert_non_null(strstr(err, "--background"));
+}
+
+static void test_cmdline_help_exits_zero(void **state)
+{
+    (void) state;
+    char *argv[] = {(char *) "stalonetray", (char *) "--help", NULL};
+    char err[1024];
+    assert_int_equal(run_cmdline(2, argv, err, sizeof(err)), 0);
+}
+
+static void test_cmdline_separate_value_is_consumed(void **state)
+{
+    (void) state;
+    char *argv[] = {(char *) "stalonetray", (char *) "--background",
+        (char *) "red", (char *) "--help", NULL};
+    char err[1024];
+    assert_int_equal(run_cmdline(4, argv, err, sizeof(err)), 0);
+}
+
+static void test_cmdline_inline_value(void **state)
+{
+    (void) state;
+    char *argv[] = {(char *) "stalonetray", (char *) "--monitor=2",
+        (char *) "--help", NULL};
+    char err[1024];
+    assert_int_equal(run_cmdline(3, argv, err, sizeof(err)), 0);
+}
+
+static void test_cmdline_optional_arg_hands_back_bad_token(void **state)
+{
+    (void) state;
+    char *argv[] = {(char *) "stalonetray", (char *) "--transparent",
+        (char *) "notabool", NULL};
+    char err[1024];
+    assert_int_equal(run_cmdline(3, argv, err, sizeof(err)), 255);
+    assert_non_null(strstr(err, "unknown command line option"));
+    assert_non_null(strstr(err, "notabool"));
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_cmdline_unknown_long_option),
+        cmocka_unit_test(test_cmdline_unknown_short_option),
+        cmocka_unit_test(test_cmdline_missing_required_argument),
+        cmocka_unit_test(test_cmdline_help_exits_zero),
+        cmocka_unit_test(test_cmdline_separate_value_is_consumed),
+        cmocka_unit_test(test_cmdline_inline_value),
+        cmocka_unit_test(test_cmdline_optional_arg_hands_back_bad_token),
         cmocka_unit_test_setup_teardown(
             test_init_default_settings_strdups_strings, reset_settings,
             teardown_settings),


### PR DESCRIPTION
Allow live configuration reload through a `SIGHUP`.

**Not every configuration parameter is currently reloadable,** and some will
perhaps never be. This is an initial implementation of this feature, so it can
evolve in the next iterations.

This also includes a couple fixes to pre-existing issues, namely:

- Unknown options passed through the command line would result in a segfault due
  to string comparisons against `NULL`. (#66)
- When restoring icon order from a previous run through the state file, ignored
  icons docking before all other icons are restored would interfere with the
  final icon order.

Hopefully this allows people to play around with the `monitor` parameter value
live, without having to start stalonetray through different means --- in cases
like starting the tray with their WMs.
