### PR TITLE
ci: enforce conventional commits and other updates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,28 @@ on:
       - master
   pull_request: {}
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  conventional-commits:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check commit messages
+        uses: webiny/action-conventional-commits@v1.4.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          allowed-commit-types: "feat,fix,chore,refactor,ci,docs,build"
+
   new-version:
     name: Version Bump Check
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,30 @@
+name: Pull Request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-title:
+    name: Title
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            refactor
+            ci
+            docs
+            build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     outputs:
       next-version: ${{ steps.next-version.outputs.version }}
-      has-next-version: ${{ steps.next-version.outputs.hasNextVersion }}
+      should-release: ${{ steps.gate.outputs.shouldRelease }}
 
     steps:
       - uses: actions/checkout@v5
@@ -29,16 +29,36 @@ jobs:
       - id: next-version
         uses: thenativeweb/get-next-version@2.7.1
 
-      - name: Show the next version
+      - name: Install meson
+        run: pip install 'meson>=1.5.0'
+
+      - name: Decide whether to release
+        id: gate
         run: |
-          echo "Should bump version: ${{ steps.next-version.outputs.hasNextVersion }}"
-          echo "Next version: ${{ steps.next-version.outputs.version }}"
+          mesonV=$(meson introspect meson.build --projectinfo | jq -r .version)
+          wantedV="${{ steps.next-version.outputs.version }}"
+          shouldBump="${{ steps.next-version.outputs.hasNextVersion }}"
+
+          echo "Should bump version: $shouldBump"
+          echo "Next version: $wantedV"
+          echo "Current version on meson.build: $mesonV"
+
+          if "$shouldBump" && [ "$mesonV" = "$wantedV" ]; then
+            echo "Version bump present in meson.build; releasing"
+            echo "shouldRelease=true" >> "$GITHUB_OUTPUT"
+          elif "$shouldBump"; then
+            echo "::warning::Commits warrant $wantedV but meson.build is $mesonV; skipping release"
+            echo "shouldRelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No version change detected, nothing to do"
+            echo "shouldRelease=false" >> "$GITHUB_OUTPUT"
+          fi
 
   create-release:
     name: Create
     runs-on: ubuntu-latest
 
-    if: needs.new-version.outputs.has-next-version == 'true'
+    if: needs.new-version.outputs.should-release == 'true'
     needs: [new-version]
 
     steps:


### PR DESCRIPTION
Enforce conventional commits, release only when meson.build is updated, and
enforce conventional commits on PR titles.

- **ci: enforce conventional commits on prs**
- **ci: release only when meson.build is updated**
- **ci: ensure pr titles are conventional**
