### PR TITLE
fix: delegate settings reloading logic to caller

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'stalonetray',
   'c',
-  version: '1.4.0',
+  version: '1.5.0',
   default_options: ['warning_level=3', 'c_std=gnu23'],
   meson_version: '>=1.1.0',
 )

--- a/src/settings.c
+++ b/src/settings.c
@@ -1523,11 +1523,12 @@ static int cmdline_is_value(const char *arg)
  * whose grabbed token fails to parse hands that token back for the loop to
  * reconsider. A missing required value, or any other parse failure, exits.
  *
- * A static flag makes every call after the first behave as a reload, skipping
- * non-reloadable options so their values are not re-parsed. */
-int parse_cmdline(int argc, char **argv, int pass)
+ * `reloading` distinguishes a SIGHUP-driven reload from the initial load; the
+ * caller supplies it (read_settings passes False, settings_reload True). On a
+ * reload, non-reloadable options are skipped so their values are not
+ * re-parsed. */
+int parse_cmdline(int argc, char **argv, int pass, int reloading)
 {
-  static int reloading = 0;
   char *progname = argv[0];
   const char *slot[1];
 
@@ -1587,7 +1588,6 @@ int parse_cmdline(int argc, char **argv, int pass)
     exit(0);
   }
 
-  reloading = 1;
   return SUCCESS;
 }
 
@@ -1781,16 +1781,14 @@ static int parse_rc_line(char *buf, int lnum, int reloading)
 
 /* Parses the active rc file into *parse_target.
  *
- * Tracks whether this is the first call ("loading") or a subsequent one
- * ("reloading") via a static flag so the function can apply slightly
- * different behavior on a SIGHUP-driven reload without leaking that detail
- * into the public API. On reloads we (a) skip params with reloadable == 0
- * inside parse_rc_line(), and (b) downgrade fatal errors to a logged
- * FAILURE so a malformed live edit doesn't take down the tray. The first
- * load preserves the original strict behavior and DIEs on errors. */
-int parse_rc(void)
+ * `reloading` (supplied by the caller -- read_settings passes False,
+ * settings_reload True) selects slightly different behavior for a
+ * SIGHUP-driven reload: we (a) skip params with reloadable == 0 inside
+ * parse_rc_line(), and (b) downgrade fatal errors to a logged FAILURE so a
+ * malformed live edit doesn't take down the tray. The initial load keeps the
+ * strict behavior and DIEs on errors. */
+int parse_rc(int reloading)
 {
-  static int reloading = 0;
   FILE *cfg = NULL;
   int rc = SUCCESS;
   int lnum = 0;
@@ -1827,8 +1825,6 @@ int parse_rc(void)
     fclose(cfg);
   }
 
-  /* From here on, the function behaves as a reload. */
-  reloading = 1;
   return rc;
 }
 
@@ -1991,8 +1987,8 @@ int settings_reload(int argc, char **argv, struct Settings *out_old)
 
   parse_target = &tmp;
   init_default_settings();
-  parse_cmdline(argc, argv, 0);
-  ok = parse_rc();
+  parse_cmdline(argc, argv, 0, True);
+  ok = parse_rc(True);
   parse_target = &settings;
   if (ok != SUCCESS) {
     /* Syntax error / missing config / etc. tmp may be partially
@@ -2003,7 +1999,7 @@ int settings_reload(int argc, char **argv, struct Settings *out_old)
     return FAILURE;
   }
   parse_target = &tmp;
-  parse_cmdline(argc, argv, 1);
+  parse_cmdline(argc, argv, 1, True);
   parse_target = &settings;
 
   /* Snapshot live settings (shallow). out_old now aliases every live heap
@@ -2101,11 +2097,11 @@ int read_settings(int argc, char **argv)
 {
   init_default_settings();
   /* Parse 0th pass command line args */
-  parse_cmdline(argc, argv, 0);
+  parse_cmdline(argc, argv, 0, False);
   /* Parse configuration files */
-  parse_rc();
+  parse_rc(False);
   /* Parse 1st pass command line args */
-  parse_cmdline(argc, argv, 1);
+  parse_cmdline(argc, argv, 1, False);
   /* Display some settings */
   LOG_TRACE(("stalonetray " VERSION " [ " FEATURE_LIST " ]\n"));
   LOG_TRACE(("bg_color_str = \"%s\"\n", settings.bg_color_str));

--- a/src/settings.h
+++ b/src/settings.h
@@ -116,15 +116,17 @@ void init_default_settings(void);
 /* Read settings from cmd line and configuration file */
 int read_settings(int argc, char **argv);
 /* Parse the rc file at settings.config_fname (or the default search path if
- * NULL) into the active settings target. Returns SUCCESS / FAILURE; on the
- * first call a syntax error DIEs, on later calls it logs and returns
- * FAILURE. Exposed for testing -- normal code goes through read_settings or
+ * NULL) into the active settings target. Returns SUCCESS / FAILURE. With
+ * reloading == False (initial load) a syntax error DIEs; with reloading ==
+ * True (SIGHUP reload) it logs, returns FAILURE, and skips non-reloadable
+ * params. Exposed for testing -- normal code goes through read_settings or
  * settings_reload. */
-int parse_rc(void);
+int parse_rc(int reloading);
 /* Parse one command-line pass into the active settings target. An unknown
  * option, a missing required value, or an unparseable value prints the usage
- * and exits. Exposed for testing -- normal code goes through read_settings. */
-int parse_cmdline(int argc, char **argv, int pass);
+ * and exits. With reloading == True (SIGHUP reload) non-reloadable options are
+ * skipped. Exposed for testing -- normal code goes through read_settings. */
+int parse_cmdline(int argc, char **argv, int pass, int reloading);
 /* Interpret all settings that either need an
  * open display or are interpreted from other
  * settings */

--- a/tests/test_settings.c
+++ b/tests/test_settings.c
@@ -224,7 +224,7 @@ static int parse_rc_with_body(const char *body)
   char *path = write_tmp_rc(body);
   free(settings.config_fname);
   settings.config_fname = strdup(path);
-  int rc = parse_rc();
+  int rc = parse_rc(False);
   cleanup_tmp_rc(path);
   return rc;
 }
@@ -327,8 +327,8 @@ static int run_cmdline(int argc, char **argv, char *err, size_t errsz)
     close(fds[0]);
     close(fds[1]);
     init_default_settings();
-    parse_cmdline(argc, argv, 0);
-    parse_cmdline(argc, argv, 1);
+    parse_cmdline(argc, argv, 0, False);
+    parse_cmdline(argc, argv, 1, False);
     _exit(0);
   }
 
@@ -431,6 +431,38 @@ static void test_cmdline_optional_arg_hands_back_bad_token(void **state)
   assert_non_null(strstr(err, "notabool"));
 }
 
+/* Regression: a full load makes two passes -- pass 0 (options needed before
+ * the rc file) then pass 1 (everything else). A bug once made the second pass
+ * behave as a SIGHUP reload, silently dropping every option not flagged
+ * reloadable (geometry, icon size, slot size, scrollbars, ...). With
+ * reloading == False both passes must apply their options. */
+static void test_cmdline_load_applies_nonreloadable_options(void **state)
+{
+  (void)state;
+  char *argv[] = {(char *)"stalonetray", (char *)"--icon-size", (char *)"48",
+      (char *)"--geometry", (char *)"5x1+0+0", NULL};
+  parse_cmdline(5, argv, 0, False);
+  parse_cmdline(5, argv, 1, False);
+  assert_int_equal(settings.icon_size, 48);
+  assert_non_null(settings.geometry_str);
+  assert_string_equal(settings.geometry_str, "5x1+0+0");
+}
+
+/* The reload counterpart of the test above: with reloading == True a
+ * non-reloadable option (icon size) is skipped, while a reloadable one
+ * (background) still applies. */
+static void test_cmdline_reload_skips_nonreloadable_options(void **state)
+{
+  (void)state;
+  char *argv[] = {(char *)"stalonetray", (char *)"--icon-size", (char *)"48",
+      (char *)"--background", (char *)"salmon", NULL};
+  int icon_size_before = settings.icon_size;
+  parse_cmdline(5, argv, 0, True);
+  parse_cmdline(5, argv, 1, True);
+  assert_int_equal(settings.icon_size, icon_size_before);
+  assert_string_equal(settings.bg_color_str, "salmon");
+}
+
 int main(void)
 {
   const struct CMUnitTest tests[] = {
@@ -443,6 +475,12 @@ int main(void)
       cmocka_unit_test(test_cmdline_negative_value_is_consumed),
       cmocka_unit_test(test_cmdline_option_after_value_option_still_errors),
       cmocka_unit_test(test_cmdline_optional_arg_hands_back_bad_token),
+      cmocka_unit_test_setup_teardown(
+          test_cmdline_load_applies_nonreloadable_options, reset_settings,
+          teardown_settings),
+      cmocka_unit_test_setup_teardown(
+          test_cmdline_reload_skips_nonreloadable_options, reset_settings,
+          teardown_settings),
       cmocka_unit_test_setup_teardown(
           test_init_default_settings_strdups_strings, reset_settings,
           teardown_settings),
@@ -459,10 +497,8 @@ int main(void)
           reset_settings, teardown_settings),
       /* parse_rc value-level tests. Pattern to extend: write a one-line
        * rc with parse_rc_with_body(), then assert the field's new value
-       * on `settings`. Only reloadable params are guaranteed to be
-       * parsed here (parse_rc's static reloading flag flips to 1 after
-       * the first test above, and non-reloadable params get skipped
-       * from then on). */
+       * on `settings`. parse_rc_with_body() passes reloading == False, so
+       * both reloadable and non-reloadable params are parsed. */
       cmocka_unit_test_setup_teardown(
           test_parse_rc_string_field, reset_settings, teardown_settings),
       cmocka_unit_test_setup_teardown(


### PR DESCRIPTION
Delegate the logic for reloading settings to the parsing functions
callers. This fixes a bug in which the two-pass parse_cmdline()
invocations would skip non-reloadable flags on the second pass.

Fixes #70.
