### PR TITLE
feat: add reloadable icon gaps

### DIFF
--- a/src/layout.c
+++ b/src/layout.c
@@ -132,6 +132,10 @@ void layout_get_size(int *width, int *height)
 {
   *width = grid_sz.x * settings.slot_size.x;
   *height = grid_sz.y * settings.slot_size.y;
+  /* Account for the inter-icon gaps: one fewer than the number of occupied
+   * slots along each axis, and none when the grid is empty. */
+  if (grid_sz.x > 0) *width += (grid_sz.x - 1) * settings.slot_gap;
+  if (grid_sz.y > 0) *height += (grid_sz.y - 1) * settings.slot_gap;
   if (settings.vertical) swap((*width), (*height));
 }
 
@@ -204,6 +208,15 @@ int layout_translate_to_window(struct TrayIcon *ti)
         - (ti->l.grd_rect.y + ti->l.grd_rect.h) * settings.slot_size.y;
   ti->l.icn_rect.w = ti->l.grd_rect.w * settings.slot_size.y;
   ti->l.icn_rect.h = ti->l.grd_rect.h * settings.slot_size.y;
+  /* Insert slot_gap pixels between adjacent icons (none before the first one
+   * in a row or column): an icon at grid index n is pushed n gaps away from
+   * the gravity-anchored edge. grd_rect.x is the major axis here (swapped in
+   * for vertical trays), so the same expression spaces both rows and columns.
+   */
+  ti->l.icn_rect.x += (settings.icon_gravity & GRAV_W ? 1 : -1)
+      * ti->l.grd_rect.x * settings.slot_gap;
+  ti->l.icn_rect.y += (settings.icon_gravity & GRAV_N ? 1 : -1)
+      * ti->l.grd_rect.y * settings.slot_gap;
   /* Swap vert & horz dimentions back */
   if (settings.vertical) {
     swap(ti->l.grd_rect.w, ti->l.grd_rect.h);

--- a/src/layout.c
+++ b/src/layout.c
@@ -574,6 +574,27 @@ int layout_unset_flag(struct TrayIcon *ti)
   return NO_MATCH;
 }
 
+int layout_rescale(void)
+{
+  /* Re-translate the existing grid layout into window coordinates for the
+   * current slot size, keeping every icon in the grid slot it already
+   * occupies. Used when only the slot pitch changes (e.g. a slot_size
+   * reload): the grid arrangement -- and therefore the on-screen order --
+   * must stay put. Unlike layout_relayout_in_list_order, this never derives
+   * positions from list order, which is not guaranteed to mirror grid order
+   * (an icon shown via icon_track_visibility_changes is placed by best fit
+   * without the order machinery that keeps the two in sync). Only the per-cell
+   * spans (which depend on the slot size) and the overall grid size are
+   * recomputed. */
+  grid_sz.x = 0;
+  grid_sz.y = 0;
+  icon_list_forall(&grid_translate_from_window);
+  icon_list_forall(&grid_recalc_size);
+  icon_list_forall(&layout_translate_to_window);
+  LOG_TRACE(("rescale: grid size %dx%d\n", grid_sz.x, grid_sz.y));
+  return SUCCESS;
+}
+
 int layout_relayout_in_list_order(void)
 {
   /* Lay icons out by walking the list and assigning sequential grid slots.

--- a/src/layout.h
+++ b/src/layout.h
@@ -58,6 +58,11 @@ int layout_translate_to_window(struct TrayIcon *ti);
  * Used by drag-to-reorder to commit the new sequence. */
 int layout_relayout_in_list_order(void);
 
+/* Re-translate the existing grid layout for the current slot size, keeping
+ * each icon in its current grid slot (and thus its on-screen order). Used when
+ * only the slot pitch changes, e.g. a slot_size reload. */
+int layout_rescale(void);
+
 /* Return next icon in tab chain */
 struct TrayIcon *layout_next(struct TrayIcon *current);
 

--- a/src/main.c
+++ b/src/main.c
@@ -895,11 +895,13 @@ static void apply_settings_reload(const struct Settings *old)
 #endif
 
   if (old->slot_size.x != settings.slot_size.x
-      || old->slot_size.y != settings.slot_size.y) {
-    /* slot_size changes the grid pitch, so re-translate every icon for the new
-     * pitch (keeping its grid slot, hence its on-screen order) and resize the
-     * tray window. tray_update_window_props's resize emits a ConfigureNotify
-     * that re-translates icon positions for the new window size. */
+      || old->slot_size.y != settings.slot_size.y
+      || old->slot_gap != settings.slot_gap) {
+    /* slot_size and slot_gap change the on-screen spacing without moving icons
+     * between grid slots, so re-translate every icon for the new pitch (keeping
+     * its grid slot, hence its on-screen order) and resize the tray window.
+     * tray_update_window_props's resize emits a ConfigureNotify that
+     * re-translates icon positions for the new window size. */
     layout_rescale();
     embedder_update_positions(True);
     tray_update_window_props();

--- a/src/main.c
+++ b/src/main.c
@@ -894,6 +894,17 @@ static void apply_settings_reload(const struct Settings *old)
   }
 #endif
 
+  if (old->slot_size.x != settings.slot_size.x
+      || old->slot_size.y != settings.slot_size.y) {
+    /* slot_size changes the grid pitch, so re-translate every icon for the new
+     * pitch (keeping its grid slot, hence its on-screen order) and resize the
+     * tray window. tray_update_window_props's resize emits a ConfigureNotify
+     * that re-translates icon positions for the new window size. */
+    layout_rescale();
+    embedder_update_positions(True);
+    tray_update_window_props();
+  }
+
   /* Walk every reload, even when the list looks unchanged: a config edit
    * is the only reason we got here and the cost is one X round-trip per
    * icon. */

--- a/src/settings.c
+++ b/src/settings.c
@@ -933,7 +933,8 @@ struct Param params[] = {
       .default_argc = 0,
       .default_argv = NULL,
 
-      .parser = (param_parser_t)&parse_int
+      .parser = (param_parser_t)&parse_int,
+      .reloadable = True
     },
     {
       .short_name = NULL,
@@ -1079,7 +1080,8 @@ struct Param params[] = {
       .default_argc = 0,
       .default_argv = NULL,
 
-      .parser = (param_parser_t)&parse_size
+      .parser = (param_parser_t)&parse_size,
+      .reloadable = True
     },
     {
       .short_name = NULL,
@@ -1828,6 +1830,34 @@ int parse_rc(int reloading)
   return rc;
 }
 
+/* Derive the maximal tray dimensions (in pixels) from max_geometry_str and the
+ * current slot size: an unset dimension means "as large as the root window",
+ * otherwise the value is in slots. Depends on slot_size, orig_tray_dims and the
+ * cached root window size, so it can be re-run on a slot_size reload. */
+static void interpret_max_tray_dims(void)
+{
+  int dummy;
+  XParseGeometry(settings.max_geometry_str, &dummy, &dummy,
+      (unsigned int *)&settings.max_tray_dims.x,
+      (unsigned int *)&settings.max_tray_dims.y);
+  LOG_TRACE(("max geometry from max_geometry_str: %dx%d\n",
+      settings.max_tray_dims.x, settings.max_tray_dims.y));
+  if (!settings.max_tray_dims.x)
+    settings.max_tray_dims.x = tray_data.root_wnd.width;
+  else {
+    settings.max_tray_dims.x *= settings.slot_size.x;
+    val_range(settings.max_tray_dims.x, settings.orig_tray_dims.x, INT_MAX);
+  }
+  if (!settings.max_tray_dims.y)
+    settings.max_tray_dims.y = tray_data.root_wnd.height;
+  else {
+    settings.max_tray_dims.y *= settings.slot_size.y;
+    val_range(settings.max_tray_dims.y, settings.orig_tray_dims.y, INT_MAX);
+  }
+  LOG_TRACE(("max geometry after normalization: %dx%d\n",
+      settings.max_tray_dims.x, settings.max_tray_dims.y));
+}
+
 /* Interpret all settings that need an open display or other settings */
 void interpret_settings(void)
 {
@@ -1835,7 +1865,6 @@ void interpret_settings(void)
       ForgetGravity, SouthGravity, SouthEastGravity, SouthWestGravity,
       ForgetGravity, NorthGravity, NorthEastGravity, NorthWestGravity};
   int geom_flags;
-  int dummy;
   XWindowAttributes root_wa;
   /* Sanitize icon size */
   val_range(settings.icon_size, MIN_ICON_SIZE, INT_MAX);
@@ -1940,25 +1969,7 @@ void interpret_settings(void)
   else
     settings.geom_gravity = NorthWestGravity;
   /* Set tray maximal width/height */
-  geom_flags = XParseGeometry(settings.max_geometry_str, &dummy, &dummy,
-      (unsigned int *)&settings.max_tray_dims.x,
-      (unsigned int *)&settings.max_tray_dims.y);
-  LOG_TRACE(("max geometry from max_geometry_str: %dx%d\n",
-      settings.max_tray_dims.x, settings.max_tray_dims.y));
-  if (!settings.max_tray_dims.x)
-    settings.max_tray_dims.x = root_wa.width;
-  else {
-    settings.max_tray_dims.x *= settings.slot_size.x;
-    val_range(settings.max_tray_dims.x, settings.orig_tray_dims.x, INT_MAX);
-  }
-  if (!settings.max_tray_dims.y)
-    settings.max_tray_dims.y = root_wa.height;
-  else {
-    settings.max_tray_dims.y *= settings.slot_size.y;
-    val_range(settings.max_tray_dims.y, settings.orig_tray_dims.y, INT_MAX);
-  }
-  LOG_TRACE(("max geometry after normalization: %dx%d\n",
-      settings.max_tray_dims.x, settings.max_tray_dims.y));
+  interpret_max_tray_dims();
   /* XXX: this assumes certain degree of symmetry and in some point
    * in the future this may not be the case... */
   tray_calc_window_size(0, 0, &tray_data.scrollbars_data.scroll_base.x,
@@ -2051,7 +2062,10 @@ int settings_reload(int argc, char **argv, struct Settings *out_old)
   ADOPT(wnd_layer);
   ADOPT(wnd_type);
   ADOPT(ignored_classes);
+  ADOPT(scrollbars_inc);
 #undef ADOPT
+  /* slot_size has no heap content, so adopt it with a plain copy. */
+  settings.slot_size = tmp.slot_size;
 
   /* Discard non-reloadable values tmp accumulated (e.g. defaults assigned
    * by init_default_settings or cmdline overrides parse_cmdline let
@@ -2070,6 +2084,25 @@ int settings_reload(int argc, char **argv, struct Settings *out_old)
     settings.transparent = False;
   }
   if (settings.transparent) settings.parent_bg = False;
+
+  /* slot_size keys several derived geometry values. Clamp it to the icon size
+   * (icon_size is not reloadable, so it is a stable floor), then carry the
+   * slot-unit tray dimensions interpret_settings() computed at startup over to
+   * the new slot size: orig_tray_dims is an integral number of slots, so it
+   * rescales exactly, and the max dimensions are recomputed from that. */
+  if (settings.slot_size.x < settings.icon_size)
+    settings.slot_size.x = settings.icon_size;
+  if (settings.slot_size.y < settings.icon_size)
+    settings.slot_size.y = settings.icon_size;
+  if (out_old->slot_size.x > 0 && settings.slot_size.x != out_old->slot_size.x)
+    settings.orig_tray_dims.x =
+        settings.orig_tray_dims.x / out_old->slot_size.x * settings.slot_size.x;
+  if (out_old->slot_size.y > 0 && settings.slot_size.y != out_old->slot_size.y)
+    settings.orig_tray_dims.y =
+        settings.orig_tray_dims.y / out_old->slot_size.y * settings.slot_size.y;
+  interpret_max_tray_dims();
+  if (settings.scrollbars_mode != SB_MODE_NONE)
+    val_range(settings.scrollbars_inc, settings.slot_size.x / 2, INT_MAX);
 
   /* Re-parse colors into a temporary first; on parse failure leave the
    * old XColor in place so the tray doesn't end up with a garbage pixel.

--- a/src/settings.c
+++ b/src/settings.c
@@ -106,6 +106,7 @@ void init_default_settings(void)
   parse_target->icon_size = FALLBACK_ICON_SIZE;
   parse_target->slot_size.x = -1;
   parse_target->slot_size.y = -1;
+  parse_target->slot_gap = 0;
   parse_target->deco_flags = DECO_NONE;
   parse_target->shrink_back_mode = 1;
   parse_target->sticky = 1;
@@ -1085,6 +1086,23 @@ struct Param params[] = {
     },
     {
       .short_name = NULL,
+      .long_name = "--slot-gap",
+      .rc_name = "slot_gap",
+      .struct_offset = offsetof(struct Settings, slot_gap),
+
+      .pass = 1,
+
+      .min_argc = 1,
+      .max_argc = 1,
+
+      .default_argc = 0,
+      .default_argv = NULL,
+
+      .parser = (param_parser_t)&parse_int,
+      .reloadable = True
+    },
+    {
+      .short_name = NULL,
       .long_name = "--sticky",
       .rc_name = "sticky",
       .struct_offset = offsetof(struct Settings, sticky),
@@ -1437,6 +1455,7 @@ void usage(char *progname)
       "    --slot-size <w>[x<h>]       set icon slot size in pixels\n"
       "                                if omitted, hight is set equal to "
       "width\n"
+      "    --slot-gap <pixels>         gap in pixels inserted between icons\n"
       "    --skip-taskbar              hide tray`s window from the taskbar\n"
       "    --sticky                    make tray`s window sticky across "
       "multiple\n"
@@ -1872,6 +1891,7 @@ void interpret_settings(void)
     settings.slot_size.x = settings.icon_size;
   if (settings.slot_size.y < settings.icon_size)
     settings.slot_size.y = settings.icon_size;
+  val_range(settings.slot_gap, 0, INT_MAX);
   /* Sanitize scrollbar settings */
   if (settings.scrollbars_mode != SB_MODE_NONE) {
     val_range(settings.scrollbars_inc, settings.slot_size.x / 2, INT_MAX);
@@ -2063,6 +2083,7 @@ int settings_reload(int argc, char **argv, struct Settings *out_old)
   ADOPT(wnd_type);
   ADOPT(ignored_classes);
   ADOPT(scrollbars_inc);
+  ADOPT(slot_gap);
 #undef ADOPT
   /* slot_size has no heap content, so adopt it with a plain copy. */
   settings.slot_size = tmp.slot_size;
@@ -2103,6 +2124,7 @@ int settings_reload(int argc, char **argv, struct Settings *out_old)
   interpret_max_tray_dims();
   if (settings.scrollbars_mode != SB_MODE_NONE)
     val_range(settings.scrollbars_inc, settings.slot_size.x / 2, INT_MAX);
+  val_range(settings.slot_gap, 0, INT_MAX);
 
   /* Re-parse colors into a temporary first; on parse failure leave the
    * old XColor in place so the tray doesn't end up with a garbage pixel.
@@ -2163,6 +2185,7 @@ int read_settings(int argc, char **argv)
   LOG_TRACE(("shrink_back_mode = %d\n", settings.shrink_back_mode));
   LOG_TRACE(("slot_size.x = %d\n", settings.slot_size.x));
   LOG_TRACE(("slot_size.y = %d\n", settings.slot_size.y));
+  LOG_TRACE(("slot_gap = %d\n", settings.slot_gap));
   LOG_TRACE(("vertical = %d\n", settings.vertical));
   LOG_TRACE(("xsync = %d\n", settings.xsync));
   return SUCCESS;

--- a/src/settings.h
+++ b/src/settings.h
@@ -72,6 +72,7 @@ struct Settings {
   /* Values */
   int icon_size; /* Icon size */
   struct Point slot_size; /* Grid slot size */
+  int slot_gap; /* Gap in pixels inserted between adjacent icons */
   int grow_gravity; /* Icon gravity (interpretation of icon_gravity_str) */
   int icon_gravity; /* Grow gravity (interpretation of grow_gravity_str) */
   int win_gravity; /* Tray window gravity (computed using grow gravity) */

--- a/stalonetray.xml.in
+++ b/stalonetray.xml.in
@@ -327,6 +327,16 @@
   </varlistentry>
 
   <varlistentry>
+  <term><option>--slot-gap</option> <replaceable>pixels</replaceable></term>
+  <term><option>slot_gap</option> <replaceable>pixels</replaceable></term>
+  <listitem><para>Insert <replaceable>pixels</replaceable> of empty space
+  between adjacent icons. The gap is added only between icons, never before the
+  first or after the last one, so <replaceable>n</replaceable> icons are
+  separated by <replaceable>n</replaceable>-1 gaps. Defaults to 0.
+  </para></listitem>
+  </varlistentry>
+
+  <varlistentry>
   <term><option>--scrollbars</option> <replaceable>mode</replaceable></term>
   <term><option>scrollbars</option> <replaceable>mode</replaceable></term>
   <listitem><para>Set scrollbar mode. Possible values:

--- a/stalonetrayrc.sample
+++ b/stalonetrayrc.sample
@@ -54,6 +54,11 @@ icon_size 24
                              # defaults to icon size
 slot_size 32x64
 
+# slot_gap <pixels>          # gap in pixels inserted between adjacent icons;
+                             # no gap is added before the first or after the
+                             # last icon; defaults to 0
+# slot_gap 4
+
 # log_level <level>          # controls the amount of logging output, level can
                              # be err (default), info, or trace (enabled only
                              # when stalonetray configured with --enable-debug)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,3 +6,12 @@ test_settings = executable(
 )
 
 test('settings', test_settings)
+
+test_layout = executable(
+  'test_layout',
+  ['test_layout.c'] + core_sources,
+  c_args: build_args,
+  dependencies: _dependencies + [cmocka_dep],
+)
+
+test('layout', test_layout)

--- a/tests/test_layout.c
+++ b/tests/test_layout.c
@@ -154,6 +154,86 @@ static void test_relayout_in_list_order_follows_list(void **state)
   assert_int_equal(hi->l.grd_rect.x, 0);
 }
 
+/* slot_gap inserts space between adjacent icons (west gravity): icon n is
+ * pushed n gaps to the right, and the tray grows by (count - 1) gaps with no
+ * gap before the first or after the last icon. */
+static void test_gap_spaces_icons_west(void **state)
+{
+  (void)state;
+  struct TrayIcon *g0 = add_icon_at(0x0, 0);
+  struct TrayIcon *g1 = add_icon_at(0x1, 1);
+  struct TrayIcon *g2 = add_icon_at(0x2, 2);
+  int w, h;
+
+  settings.slot_gap = 10;
+  layout_rescale();
+
+  assert_int_equal(g0->l.icn_rect.x, 0); /* no leading gap */
+  assert_int_equal(g1->l.icn_rect.x, 30); /* 20 + 1 gap */
+  assert_int_equal(g2->l.icn_rect.x, 60); /* 40 + 2 gaps */
+
+  /* 3 slots * 20px + 2 gaps * 10px, no trailing gap. */
+  layout_get_size(&w, &h);
+  assert_int_equal(w, 80);
+  assert_int_equal(h, 16);
+}
+
+/* A single icon gets no gap at all, and the tray is just one slot wide. */
+static void test_gap_single_icon_has_no_gap(void **state)
+{
+  (void)state;
+  struct TrayIcon *only = add_icon_at(0x0, 0);
+  int w, h;
+
+  settings.slot_gap = 10;
+  layout_rescale();
+
+  assert_int_equal(only->l.icn_rect.x, 0);
+  layout_get_size(&w, &h);
+  assert_int_equal(w, 20);
+}
+
+/* With east gravity the right edge stays anchored, so the gap pushes icons
+ * further left; the leftmost icon still lands at x=0 (no edge gap). */
+static void test_gap_east_gravity(void **state)
+{
+  (void)state;
+  struct TrayIcon *g0 = add_icon_at(0x0, 0);
+  struct TrayIcon *g1 = add_icon_at(0x1, 1);
+  struct TrayIcon *g2 = add_icon_at(0x2, 2);
+
+  settings.icon_gravity = GRAV_N | GRAV_E;
+  settings.slot_gap = 10;
+  tray_data.xsh.width = 80; /* the size layout_get_size would report */
+  layout_rescale();
+
+  assert_int_equal(g0->l.icn_rect.x, 60); /* rightmost, anchored */
+  assert_int_equal(g1->l.icn_rect.x, 30);
+  assert_int_equal(g2->l.icn_rect.x, 0); /* leftmost, no edge gap */
+}
+
+/* A vertical tray spaces icons along the major (y) axis. */
+static void test_gap_vertical(void **state)
+{
+  (void)state;
+  struct TrayIcon *g0 = add_icon_at(0x0, 0);
+  struct TrayIcon *g1 = add_icon_at(0x1, 1);
+  struct TrayIcon *g2 = add_icon_at(0x2, 2);
+  int w, h;
+
+  settings.vertical = 1;
+  settings.slot_gap = 10;
+  layout_rescale();
+
+  assert_int_equal(g0->l.icn_rect.y, 0);
+  assert_int_equal(g1->l.icn_rect.y, 26); /* 16 + 1 gap */
+  assert_int_equal(g2->l.icn_rect.y, 52); /* 32 + 2 gaps */
+
+  /* Major axis is vertical: height carries the gaps. */
+  layout_get_size(&w, &h);
+  assert_int_equal(h, 80); /* 3 * 16 + 2 * 10 */
+}
+
 int main(void)
 {
   const struct CMUnitTest tests[] = {
@@ -165,6 +245,12 @@ int main(void)
           test_rescale_recomputes_cell_spans, setup, teardown),
       cmocka_unit_test_setup_teardown(
           test_relayout_in_list_order_follows_list, setup, teardown),
+      cmocka_unit_test_setup_teardown(
+          test_gap_spaces_icons_west, setup, teardown),
+      cmocka_unit_test_setup_teardown(
+          test_gap_single_icon_has_no_gap, setup, teardown),
+      cmocka_unit_test_setup_teardown(test_gap_east_gravity, setup, teardown),
+      cmocka_unit_test_setup_teardown(test_gap_vertical, setup, teardown),
   };
   return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/test_layout.c
+++ b/tests/test_layout.c
@@ -1,0 +1,170 @@
+/* Unit tests for layout rescaling on a slot_size change.
+ *
+ * These exercise the pure layout math (no X display): layout.c, icons.c and the
+ * rest of core_sources are linked, settings/tray_data are set up by hand, and
+ * the functions under test only read/write those globals plus the icon list.
+ *
+ * Regression focus: a slot_size reload must keep every icon in the grid slot it
+ * already occupies. layout_rescale() must NOT re-derive positions from list
+ * order, which is not guaranteed to mirror grid order (an icon shown via the
+ * hidden->visible path is placed by best fit, leaving its list position and
+ * grid slot out of sync -- this reordered the tray on the first SIGHUP). */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <setjmp.h> /* cmocka requires this before <cmocka.h> */
+
+#include <cmocka.h>
+
+#include "../src/icons.h"
+#include "../src/layout.h"
+#include "../src/settings.h"
+#include "../src/tray.h"
+
+/* A fresh, display-free environment per test: default settings, a zeroed
+ * tray_data (so scrollbar offsets are zero), a horizontal west-gravity tray
+ * with a known slot pitch and generous max dimensions. */
+static int setup(void **state)
+{
+  (void)state;
+  init_default_settings();
+  memset(&tray_data, 0, sizeof(tray_data));
+  settings.vertical = 0;
+  settings.icon_gravity = GRAV_N | GRAV_W;
+  settings.scrollbars_mode = SB_MODE_NONE;
+  settings.slot_size.x = 20;
+  settings.slot_size.y = 16;
+  settings.max_tray_dims.x = 1000;
+  settings.max_tray_dims.y = 1000;
+  return 0;
+}
+
+static int teardown(void **state)
+{
+  (void)state;
+  while (icons_head != NULL) icon_list_free(icons_head);
+  free_settings(&settings);
+  return 0;
+}
+
+/* Append a laid-out, visible icon at a given grid slot. icon_list_new prepends,
+ * so the first-created icon ends up at the list tail. */
+static struct TrayIcon *add_icon_at(Window wid, int grid_x)
+{
+  struct TrayIcon *ti = icon_list_new(wid, 0);
+  ti->is_visible = True;
+  ti->is_layed_out = True;
+  ti->l.wnd_sz.x = 16;
+  ti->l.wnd_sz.y = 16;
+  ti->l.grd_rect.x = grid_x;
+  ti->l.grd_rect.y = 0;
+  ti->l.grd_rect.w = 1;
+  ti->l.grd_rect.h = 1;
+  return ti;
+}
+
+/* The core regression: list order diverges from grid order (the list-head icon
+ * sits at grid slot 2), and layout_rescale must leave every grid slot exactly
+ * where it was -- only the pixel translation changes. */
+static void test_rescale_preserves_grid_slots(void **state)
+{
+  (void)state;
+  /* Build list [head, mid, tail] = [slot 2, slot 0, slot 1] by creating the
+   * tail first. This mirrors the bug: a best-fit-placed icon (slot 2) lands at
+   * the list head while the rest stay in grid order. */
+  struct TrayIcon *g1 = add_icon_at(0x1, 1); /* list tail */
+  struct TrayIcon *g0 = add_icon_at(0x0, 0); /* list middle */
+  struct TrayIcon *hi = add_icon_at(0x2, 2); /* list head, high slot */
+  int w, h;
+
+  assert_ptr_equal(icons_head, hi);
+
+  layout_rescale();
+
+  /* Grid slots are untouched (no reordering by list position). */
+  assert_int_equal(hi->l.grd_rect.x, 2);
+  assert_int_equal(g0->l.grd_rect.x, 0);
+  assert_int_equal(g1->l.grd_rect.x, 1);
+
+  /* West gravity, no scrollbars: pixel x = slot * slot_size.x. */
+  assert_int_equal(hi->l.icn_rect.x, 40);
+  assert_int_equal(g0->l.icn_rect.x, 0);
+  assert_int_equal(g1->l.icn_rect.x, 20);
+
+  /* Grid spans three slots of 20px. */
+  layout_get_size(&w, &h);
+  assert_int_equal(w, 60);
+  assert_int_equal(h, 16);
+}
+
+/* A new slot pitch re-translates pixels but keeps slots (and grid extent in
+ * slot units) the same. */
+static void test_rescale_applies_new_slot_size(void **state)
+{
+  (void)state;
+  add_icon_at(0x1, 1);
+  struct TrayIcon *g0 = add_icon_at(0x0, 0);
+  struct TrayIcon *hi = add_icon_at(0x2, 2);
+  int w, h;
+
+  settings.slot_size.x = 30;
+  layout_rescale();
+
+  assert_int_equal(hi->l.grd_rect.x, 2);
+  assert_int_equal(g0->l.icn_rect.x, 0);
+  assert_int_equal(hi->l.icn_rect.x, 60);
+
+  layout_get_size(&w, &h);
+  assert_int_equal(w, 90); /* 3 slots * 30px */
+}
+
+/* Per-cell spans depend on the slot size: an icon wider than the slot occupies
+ * more than one cell, and that recomputes when the pitch changes. */
+static void test_rescale_recomputes_cell_spans(void **state)
+{
+  (void)state;
+  struct TrayIcon *big = add_icon_at(0x9, 0);
+  big->l.wnd_sz.x = 40; /* two 20px cells wide */
+
+  layout_rescale();
+  assert_int_equal(big->l.grd_rect.w, 2);
+
+  settings.slot_size.x = 40; /* now fits in a single cell */
+  layout_rescale();
+  assert_int_equal(big->l.grd_rect.w, 1);
+}
+
+/* Contrast/guard: layout_relayout_in_list_order deliberately assigns slots from
+ * list order, so it WOULD move the list-head icon to slot 0. This is exactly
+ * why the slot_size reload path must not use it. */
+static void test_relayout_in_list_order_follows_list(void **state)
+{
+  (void)state;
+  add_icon_at(0x1, 1);
+  add_icon_at(0x0, 0);
+  struct TrayIcon *hi = add_icon_at(0x2, 2); /* list head */
+
+  layout_relayout_in_list_order();
+
+  /* The head icon is reassigned to the first slot -- the reordering bug. */
+  assert_int_equal(hi->l.grd_rect.x, 0);
+}
+
+int main(void)
+{
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test_setup_teardown(
+          test_rescale_preserves_grid_slots, setup, teardown),
+      cmocka_unit_test_setup_teardown(
+          test_rescale_applies_new_slot_size, setup, teardown),
+      cmocka_unit_test_setup_teardown(
+          test_rescale_recomputes_cell_spans, setup, teardown),
+      cmocka_unit_test_setup_teardown(
+          test_relayout_in_list_order_follows_list, setup, teardown),
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/test_settings.c
+++ b/tests/test_settings.c
@@ -305,6 +305,34 @@ static void test_settings_reload_adopts_scrollbars_step(void **state)
   cleanup_tmp_rc(rc_path);
 }
 
+/* slot_gap is reloadable, and a negative value is clamped to zero. */
+static void test_settings_reload_adopts_slot_gap(void **state)
+{
+  (void)state;
+  settings.slot_gap = 0;
+
+  char *rc_path = write_tmp_rc("slot_gap 12\n");
+  free(settings.config_fname);
+  settings.config_fname = strdup(rc_path);
+
+  char *argv[] = {(char *)"test"};
+  struct Settings old;
+  assert_int_equal(settings_reload(1, argv, &old), 1 /* SUCCESS */);
+  assert_int_equal(settings.slot_gap, 12);
+  free_settings(&old);
+  cleanup_tmp_rc(rc_path);
+
+  settings.slot_gap = 12;
+  rc_path = write_tmp_rc("slot_gap -5\n");
+  free(settings.config_fname);
+  settings.config_fname = strdup(rc_path);
+  assert_int_equal(settings_reload(1, argv, &old), 1 /* SUCCESS */);
+  assert_int_equal(settings.slot_gap, 0);
+
+  free_settings(&old);
+  cleanup_tmp_rc(rc_path);
+}
+
 /* ------------------------------------------------------------- parse_rc */
 
 /* Convenience: drop a one-liner rc into a temp file and point
@@ -596,6 +624,8 @@ int main(void)
       cmocka_unit_test_setup_teardown(
           test_settings_reload_adopts_scrollbars_step, reset_settings,
           teardown_settings),
+      cmocka_unit_test_setup_teardown(test_settings_reload_adopts_slot_gap,
+          reset_settings, teardown_settings),
       /* parse_rc value-level tests. Pattern to extend: write a one-line
        * rc with parse_rc_with_body(), then assert the field's new value
        * on `settings`. parse_rc_with_body() passes reloading == False, so

--- a/tests/test_settings.c
+++ b/tests/test_settings.c
@@ -215,6 +215,96 @@ static void test_settings_reload_no_double_free(void **state)
   cleanup_tmp_rc(rc_path);
 }
 
+/* slot_size is reloadable: a new value in the config is adopted into the live
+ * settings (a single number sets both axes, like the cmdline/rc parser). */
+static void test_settings_reload_adopts_slot_size(void **state)
+{
+  (void)state;
+  settings.icon_size = 16;
+  settings.slot_size.x = 20;
+  settings.slot_size.y = 20;
+
+  char *rc_path = write_tmp_rc("slot_size 40\n");
+  free(settings.config_fname);
+  settings.config_fname = strdup(rc_path);
+
+  char *argv[] = {(char *)"test"};
+  struct Settings old;
+  assert_int_equal(settings_reload(1, argv, &old), 1 /* SUCCESS */);
+  assert_int_equal(settings.slot_size.x, 40);
+  assert_int_equal(settings.slot_size.y, 40);
+
+  free_settings(&old);
+  cleanup_tmp_rc(rc_path);
+}
+
+/* A reloaded slot_size below the icon size is clamped up to it, mirroring
+ * interpret_settings(); icon_size itself is not reloadable. */
+static void test_settings_reload_clamps_slot_size_to_icon_size(void **state)
+{
+  (void)state;
+  settings.icon_size = 24;
+  settings.slot_size.x = 32;
+  settings.slot_size.y = 32;
+
+  char *rc_path = write_tmp_rc("slot_size 8\n");
+  free(settings.config_fname);
+  settings.config_fname = strdup(rc_path);
+
+  char *argv[] = {(char *)"test"};
+  struct Settings old;
+  assert_int_equal(settings_reload(1, argv, &old), 1 /* SUCCESS */);
+  assert_int_equal(settings.slot_size.x, 24);
+  assert_int_equal(settings.slot_size.y, 24);
+
+  free_settings(&old);
+  cleanup_tmp_rc(rc_path);
+}
+
+/* orig_tray_dims is an integral number of slots, so a slot_size reload must
+ * carry it over to the new pitch (here 5x2 slots at 20px -> 30px). */
+static void test_settings_reload_rescales_orig_tray_dims(void **state)
+{
+  (void)state;
+  settings.icon_size = 16;
+  settings.slot_size.x = 20;
+  settings.slot_size.y = 20;
+  settings.orig_tray_dims.x = 100; /* 5 slots */
+  settings.orig_tray_dims.y = 40; /* 2 slots */
+
+  char *rc_path = write_tmp_rc("slot_size 30\n");
+  free(settings.config_fname);
+  settings.config_fname = strdup(rc_path);
+
+  char *argv[] = {(char *)"test"};
+  struct Settings old;
+  assert_int_equal(settings_reload(1, argv, &old), 1 /* SUCCESS */);
+  assert_int_equal(settings.orig_tray_dims.x, 150);
+  assert_int_equal(settings.orig_tray_dims.y, 60);
+
+  free_settings(&old);
+  cleanup_tmp_rc(rc_path);
+}
+
+/* scrollbars_step (scrollbars_inc) is reloadable too. */
+static void test_settings_reload_adopts_scrollbars_step(void **state)
+{
+  (void)state;
+  settings.scrollbars_inc = 5;
+
+  char *rc_path = write_tmp_rc("scrollbars_step 50\n");
+  free(settings.config_fname);
+  settings.config_fname = strdup(rc_path);
+
+  char *argv[] = {(char *)"test"};
+  struct Settings old;
+  assert_int_equal(settings_reload(1, argv, &old), 1 /* SUCCESS */);
+  assert_int_equal(settings.scrollbars_inc, 50);
+
+  free_settings(&old);
+  cleanup_tmp_rc(rc_path);
+}
+
 /* ------------------------------------------------------------- parse_rc */
 
 /* Convenience: drop a one-liner rc into a temp file and point
@@ -495,6 +585,17 @@ int main(void)
           teardown_settings),
       cmocka_unit_test_setup_teardown(test_settings_reload_no_double_free,
           reset_settings, teardown_settings),
+      cmocka_unit_test_setup_teardown(test_settings_reload_adopts_slot_size,
+          reset_settings, teardown_settings),
+      cmocka_unit_test_setup_teardown(
+          test_settings_reload_clamps_slot_size_to_icon_size, reset_settings,
+          teardown_settings),
+      cmocka_unit_test_setup_teardown(
+          test_settings_reload_rescales_orig_tray_dims, reset_settings,
+          teardown_settings),
+      cmocka_unit_test_setup_teardown(
+          test_settings_reload_adopts_scrollbars_step, reset_settings,
+          teardown_settings),
       /* parse_rc value-level tests. Pattern to extend: write a one-line
        * rc with parse_rc_with_body(), then assert the field's new value
        * on `settings`. parse_rc_with_body() passes reloading == False, so


### PR DESCRIPTION
Add a reloadable `slot_gap` setting and make the `slot_size` setting reloadable.

The "slot gap" eliminates "duplicated" margins inbetween icons and extra margins
on the edges of the tray area.

- **feat: make slot_size reloadable**
- **feat: add more flexible slot_gap setting**
